### PR TITLE
♻️ PPD-46: Refactor to make room for search that takes list of prison ids

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerSearchResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerSearchResource.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonerListCriteria
 import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonerSearchService
-import uk.gov.justice.digital.hmpps.prisonersearch.services.SearchCriteria
+import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonSearch
 import javax.validation.Valid
 
 @RestController
@@ -28,8 +28,8 @@ class PrisonerSearchResource(private val prisonerSearchService: PrisonerSearchSe
 
     @PostMapping("/match")
     @Operation(summary = "Match prisoners by criteria", description = "Requires GLOBAL_SEARCH role")
-    fun findByCriteria(@Parameter(required = true) @RequestBody searchCriteria: SearchCriteria) =
-        prisonerSearchService.findBySearchCriteria(searchCriteria)
+    fun findByCriteria(@Parameter(required = true) @RequestBody prisonSearch: PrisonSearch) =
+        prisonerSearchService.findBySearchCriteria(prisonSearch.toSearchCriteria())
 
     @PostMapping("/prisoner-numbers")
     @Operation(summary = "Match prisoners by a list of prisoner numbers", description = "Requires GLOBAL_SEARCH role")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonSearch.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.services
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Search Criteria for Prisoner Search")
-data class SearchCriteria(
+data class PrisonSearch(
   @Schema(
     description = "Prisoner identifier, one of prisoner number, book number, booking ID or PNC",
     example = "A1234AA,"
@@ -13,11 +13,20 @@ data class SearchCriteria(
   val firstName: String?,
   @Schema(description = "Last Name", example = "Smith")
   val lastName: String?,
-  @Schema(description = "List of Prison Ids (can include OUT and TRN) to restrict the search by. Unrestricted if not supplied or null", example = "[\"MDI\"]")
-  val prisonIds: List<String>? = null,
+  @Schema(description = "Prison Id, Prison Id or OUT or TRN", example = "MDI")
+  val prisonId: String? = null,
   @Schema(description = "Include aliases in search", example = "false", required = false, defaultValue = "false")
   val includeAliases: Boolean = false
 ) {
   @Schema(hidden = true)
   fun isValid() = !(firstName.isNullOrBlank() && lastName.isNullOrBlank() && prisonerIdentifier.isNullOrBlank())
+
+  @Schema(hidden = true)
+  fun toSearchCriteria() = SearchCriteria(
+    prisonerIdentifier = prisonerIdentifier,
+    firstName = firstName,
+    lastName = lastName,
+    prisonIds = prisonId?.let { listOf(it) },
+    includeAliases = includeAliases
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSearchService.kt
@@ -217,7 +217,7 @@ class PrisonerSearchService(
       "clientId" to authenticationHolder.currentClientId(),
       "lastname" to searchCriteria.lastName,
       "firstname" to searchCriteria.firstName,
-      "prisonId" to searchCriteria.prisonId,
+      "prisonId" to searchCriteria.prisonIds.toString(),
       "prisonerIdentifier" to searchCriteria.prisonerIdentifier,
       "includeAliases" to searchCriteria.includeAliases.toString()
     )
@@ -267,5 +267,5 @@ inline infix fun Result.onMatch(block: (Result.Match) -> Nothing): Unit? {
 
 private fun BoolQueryBuilder.withDefaults(searchCriteria: SearchCriteria): BoolQueryBuilder? {
   return this
-    .filterWhenPresent("prisonId", searchCriteria.prisonId)
+    .filterWhenPresent("prisonId", searchCriteria.prisonIds)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/SearchOperations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/SearchOperations.kt
@@ -31,10 +31,14 @@ fun BoolQueryBuilder.filterWhenPresent(query: String, value: Any?): BoolQueryBui
   value.takeIf {
     when(it) {
       is String -> it.isNotBlank()
+      is List<*> -> it.isNotEmpty()
       else -> true
     }
   }?.let {
-    this.filter(QueryBuilders.matchQuery(query, it))
+    when(it) {
+      is List<*> -> this.filter(shouldMatchOneOf(query, it))
+      else -> this.filter(QueryBuilders.matchQuery(query, it))
+    }
   }
   return this
 }
@@ -102,14 +106,13 @@ fun BoolQueryBuilder.mustKeyword(value: Any?, query: String): BoolQueryBuilder {
   return this
 }
 
-
 fun BoolQueryBuilder.mustMatchOneOf(query: String, values: List<Any>): BoolQueryBuilder {
   val nestedQuery = QueryBuilders.boolQuery()
   values.forEach { nestedQuery.should(QueryBuilders.boolQuery().must(query, it)) }
   return this.must(nestedQuery)
 }
 
-fun shouldMatchOneOf(query: String, values: List<Any>): BoolQueryBuilder {
+fun shouldMatchOneOf(query: String, values: List<*>): BoolQueryBuilder {
   val nestedQuery = QueryBuilders.boolQuery()
   values.forEach { nestedQuery.should(QueryBuilders.matchQuery(query, it)) }
   return nestedQuery

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/MessageIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/MessageIntegrationTest.kt
@@ -6,7 +6,7 @@ import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.prisonersearch.model.SyncIndex
-import uk.gov.justice.digital.hmpps.prisonersearch.services.SearchCriteria
+import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonSearch
 
 
 class MessageIntegrationTest : QueueIntegrationTest() {
@@ -34,7 +34,7 @@ class MessageIntegrationTest : QueueIntegrationTest() {
 
   @Test
   fun `will consume a new prisoner booking update`() {
-    search(SearchCriteria("A7089FD", null, null), "/results/empty.json")
+    search(PrisonSearch("A7089FD", null, null), "/results/empty.json")
 
     val message = "/messages/offenderDetailsChanged.json".readResourceAsText()
 
@@ -46,12 +46,12 @@ class MessageIntegrationTest : QueueIntegrationTest() {
     await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
     await untilCallTo { prisonRequestCountFor("/api/offenders/A7089FD") } matches { it == 1 }
 
-      search(SearchCriteria("A7089FD", null, null), "/results/search_results_merge1.json")
+      search(PrisonSearch("A7089FD", null, null), "/results/search_results_merge1.json")
   }
 
   @Test
   fun `will consume a delete request and remove`() {
-    search(SearchCriteria("A7089FC", null, null), "/results/search_results_to_delete.json")
+    search(PrisonSearch("A7089FC", null, null), "/results/search_results_to_delete.json")
 
     val message = "/messages/offenderDelete.json".readResourceAsText()
 
@@ -62,12 +62,12 @@ class MessageIntegrationTest : QueueIntegrationTest() {
 
     await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
 
-    search(SearchCriteria("A7089FC", null, null), "/results/empty.json")
+    search(PrisonSearch("A7089FC", null, null), "/results/empty.json")
   }
 
   @Test
   fun `will consume and check for merged record and remove`() {
-    search(SearchCriteria("A7089FA", null, null), "/results/search_results_A7089FA.json")
+    search(PrisonSearch("A7089FA", null, null), "/results/search_results_A7089FA.json")
 
     val message = "/messages/offenderMerge.json".readResourceAsText()
 
@@ -78,8 +78,8 @@ class MessageIntegrationTest : QueueIntegrationTest() {
 
     await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
 
-    search(SearchCriteria("A7089FB", null, null), "/results/search_results_A7089FB.json")
-    search(SearchCriteria("A7089FA", null, null), "/results/empty.json")
+    search(PrisonSearch("A7089FB", null, null), "/results/search_results_A7089FB.json")
+    search(PrisonSearch("A7089FA", null, null), "/results/empty.json")
   }
 
   @Test
@@ -93,7 +93,7 @@ class MessageIntegrationTest : QueueIntegrationTest() {
       .jsonPath("index-status.currentIndex").isEqualTo(SyncIndex.INDEX_B.name)
       .jsonPath("index-status.inProgress").isEqualTo("false")
 
-    search(SearchCriteria("A7089FE", null, null), "/results/empty.json")
+    search(PrisonSearch("A7089FE", null, null), "/results/empty.json")
 
     resetStubs()
     // Start re-indexing
@@ -128,7 +128,7 @@ class MessageIntegrationTest : QueueIntegrationTest() {
       .jsonPath("index-status.inProgress").isEqualTo("true")
       .jsonPath("index-size.${SyncIndex.INDEX_A.name}").isEqualTo("19")
 
-    search(SearchCriteria("A7089FE", null, null), "/results/search_results_A7089FE.json")
+    search(PrisonSearch("A7089FE", null, null), "/results/search_results_A7089FE.json")
 
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/QueueIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/QueueIntegrationTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.model.PrisonerB
 import uk.gov.justice.digital.hmpps.prisonersearch.model.SyncIndex
 import uk.gov.justice.digital.hmpps.prisonersearch.services.GlobalSearchCriteria
 import uk.gov.justice.digital.hmpps.prisonersearch.services.IndexQueueService
-import uk.gov.justice.digital.hmpps.prisonersearch.services.SearchCriteria
+import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonSearch
 
 
 @ActiveProfiles(profiles = ["test", "test-queue"])
@@ -130,9 +130,9 @@ abstract class QueueIntegrationTest : IntegrationTest() {
     }
   }
 
-  fun search(searchCriteria: SearchCriteria, fileAssert: String) {
+  fun search(prisonSearch: PrisonSearch, fileAssert: String) {
     webTestClient.post().uri("/prisoner-search/match")
-      .body(BodyInserters.fromValue(gson.toJson(searchCriteria)))
+      .body(BodyInserters.fromValue(gson.toJson(prisonSearch)))
       .headers(setAuthorisation(roles = listOf("ROLE_GLOBAL_SEARCH")))
       .header("Content-Type", "application/json")
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/GlobalSearchResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/GlobalSearchResourceTest.kt
@@ -6,7 +6,7 @@ import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.prisonersearch.QueueIntegrationTest
 import uk.gov.justice.digital.hmpps.prisonersearch.services.Gender
 import uk.gov.justice.digital.hmpps.prisonersearch.services.GlobalSearchCriteria
-import uk.gov.justice.digital.hmpps.prisonersearch.services.SearchCriteria
+import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonSearch
 import java.time.LocalDate
 
 class GlobalSearchResourceTest : QueueIntegrationTest() {
@@ -45,7 +45,7 @@ class GlobalSearchResourceTest : QueueIntegrationTest() {
   fun `access forbidden when no role`() {
 
     webTestClient.post().uri("/global-search")
-      .body(BodyInserters.fromValue(gson.toJson(SearchCriteria("A7089EY", "john", "smith", "MDI"))))
+      .body(BodyInserters.fromValue(gson.toJson(GlobalSearchCriteria("A7089EY", "john", "smith", null, null, null))))
       .headers(setAuthorisation())
       .header("Content-Type", "application/json")
       .exchange()
@@ -56,7 +56,7 @@ class GlobalSearchResourceTest : QueueIntegrationTest() {
   fun `bad request when no criteria provided`() {
 
     webTestClient.post().uri("/global-search")
-      .body(BodyInserters.fromValue(gson.toJson(SearchCriteria(null, null, null))))
+      .body(BodyInserters.fromValue(gson.toJson(GlobalSearchCriteria(null, null, null, null, null, null))))
       .headers(setAuthorisation(roles = listOf("ROLE_GLOBAL_SEARCH")))
       .header("Content-Type", "application/json")
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerSearchResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerSearchResourceTest.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.prisonersearch.QueueIntegrationTest
-import uk.gov.justice.digital.hmpps.prisonersearch.services.SearchCriteria
+import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonSearch
 
 class PrisonerSearchResourceTest : QueueIntegrationTest() {
 
@@ -42,7 +42,7 @@ class PrisonerSearchResourceTest : QueueIntegrationTest() {
   fun `access forbidden when no role`() {
 
     webTestClient.post().uri("/prisoner-search/match")
-      .body(BodyInserters.fromValue(gson.toJson(SearchCriteria("A7089EY", "john", "smith", "MDI"))))
+      .body(BodyInserters.fromValue(gson.toJson(PrisonSearch("A7089EY", "john", "smith", "MDI"))))
       .headers(setAuthorisation())
       .header("Content-Type", "application/json")
       .exchange()
@@ -53,7 +53,7 @@ class PrisonerSearchResourceTest : QueueIntegrationTest() {
   fun `bad request when no criteria provided`() {
 
     webTestClient.post().uri("/prisoner-search/match")
-      .body(BodyInserters.fromValue(gson.toJson(SearchCriteria(null, null, null))))
+      .body(BodyInserters.fromValue(gson.toJson(PrisonSearch(null, null, null))))
       .headers(setAuthorisation(roles = listOf("ROLE_GLOBAL_SEARCH")))
       .header("Content-Type", "application/json")
       .exchange()
@@ -92,142 +92,142 @@ class PrisonerSearchResourceTest : QueueIntegrationTest() {
 
   @Test
   fun `can perform a match on prisoner number`() {
-    search(SearchCriteria("A7089EY", null, null), "/results/search_results_smith.json")
+    search(PrisonSearch("A7089EY", null, null), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match wrong prisoner number but correct name`() {
-    search(SearchCriteria("X7089EY", "JOHN", "SMITH"), "/results/search_results_smith.json")
+    search(PrisonSearch("X7089EY", "JOHN", "SMITH"), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on PNC number`() {
-    search(SearchCriteria("12/394773H", null, null), "/results/search_results_smith.json")
+    search(PrisonSearch("12/394773H", null, null), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on CRO number`() {
-    search(SearchCriteria("29906/12J", null, null), "/results/search_results_smith.json")
+    search(PrisonSearch("29906/12J", null, null), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on book number`() {
-    search(SearchCriteria("V61585", null, null), "/results/search_results_smith.json")
+    search(PrisonSearch("V61585", null, null), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on booking Id`() {
-    search(SearchCriteria("1900836", null, null), "/results/search_results_smith.json")
+    search(PrisonSearch("1900836", null, null), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can not match when name is mis-spelt`() {
-    search(SearchCriteria(null, "jon", "smith"), "/results/empty.json")
+    search(PrisonSearch(null, "jon", "smith"), "/results/empty.json")
   }
 
   @Test
   fun `can not match when name is mis-spelt and wrong prison`() {
-    search(SearchCriteria(null, "jon", "smith", "LEI"), "/results/empty.json")
+    search(PrisonSearch(null, "jon", "smith", "LEI"), "/results/empty.json")
   }
 
   @Test
   fun `can not match when name of prisoner does not exist`() {
-    search(SearchCriteria(null, "trevor", "willis"), "/results/empty.json")
+    search(PrisonSearch(null, "trevor", "willis"), "/results/empty.json")
   }
 
   @Test
   fun `can perform a match on a first name only`() {
-    search(SearchCriteria(null, "john", null), "/results/search_results_john.json")
+    search(PrisonSearch(null, "john", null), "/results/search_results_john.json")
   }
 
   @Test
   fun `can perform a match on a first and last name only`() {
-    search(SearchCriteria(null, "david", "doe"), "/results/search_results_david.json")
+    search(PrisonSearch(null, "david", "doe"), "/results/search_results_david.json")
   }
 
   @Test
   fun `can perform a match on a first name only filter by prison`() {
-    search(SearchCriteria(null, "john", null, "MDI"), "/results/search_results_smith.json")
+    search(PrisonSearch(null, "john", null, "MDI"), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on a last name only`() {
-    search(SearchCriteria(null, null, "smith"), "/results/search_results_smith.json")
+    search(PrisonSearch(null, null, "smith"), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on first and last name only`() {
-    search(SearchCriteria(null, "john", "smith"), "/results/search_results_smith.json")
+    search(PrisonSearch(null, "john", "smith"), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on first and last name only in specific prison`() {
-    search(SearchCriteria(null, "john", "smith", "MDI"), "/results/search_results_smith.json")
+    search(PrisonSearch(null, "john", "smith", "MDI"), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a match on first and last name only in wrong prison`() {
-    search(SearchCriteria(null, "john", "smith", "LEI"), "/results/empty.json")
+    search(PrisonSearch(null, "john", "smith", "LEI"), "/results/empty.json")
   }
 
   @Test
   fun `can perform a match on first and last name in alias`() {
-    search(SearchCriteria(null, "master", "cordian", null, true), "/results/search_results_smyth.json")
+    search(PrisonSearch(null, "master", "cordian", null, true), "/results/search_results_smyth.json")
   }
 
   @Test
   fun `can perform a match on first and last name in alias but they must be from the same record`() {
-    search(SearchCriteria(null, "master", "stark", null, true), "/results/empty.json")
+    search(PrisonSearch(null, "master", "stark", null, true), "/results/empty.json")
   }
 
   @Test
   fun `can perform a match on first and last name in alias but they must be from the same record matches`() {
-    search(SearchCriteria(null, "tony", "stark", null, true), "/results/search_results_smyth.json")
+    search(PrisonSearch(null, "tony", "stark", null, true), "/results/search_results_smyth.json")
   }
 
   @Test
   fun `can perform a match on firstname only in alias`() {
-    search(SearchCriteria(null, "master", null, null, true), "/results/search_results_smyth.json")
+    search(PrisonSearch(null, "master", null, null, true), "/results/search_results_smyth.json")
   }
 
   @Test
   fun `can perform a match on last name only in alias`() {
-    search(SearchCriteria(null, null, "cordian", null, true), "/results/search_results_smyth.json")
+    search(PrisonSearch(null, null, "cordian", null, true), "/results/search_results_smyth.json")
   }
 
   @Test
   fun `can perform a match on first and last name in alias but with alias search off`() {
-    search(SearchCriteria(null, "master", "cordian", null, false), "/results/empty.json")
+    search(PrisonSearch(null, "master", "cordian", null, false), "/results/empty.json")
   }
 
   @Test
   fun `can perform a match on firstname only in alias but with alias search off`() {
-    search(SearchCriteria(null, "master", null, null, false), "/results/empty.json")
+    search(PrisonSearch(null, "master", null, null, false), "/results/empty.json")
   }
 
   @Test
   fun `can perform a match on last name only in alias but with alias search off`() {
-    search(SearchCriteria(null, null, "cordian", null, false), "/results/empty.json")
+    search(PrisonSearch(null, null, "cordian", null, false), "/results/empty.json")
   }
 
   @Test
   fun `can perform a match on a last name and specific prison`() {
-    search(SearchCriteria(null, null, "smyth", "LEI"), "/results/search_results_smyth.json")
+    search(PrisonSearch(null, null, "smyth", "LEI"), "/results/search_results_smyth.json")
   }
 
   @Test
-  fun `can perform a which returns no results as not in that prison`() {
-    search(SearchCriteria(null, null, "smyth", "MDI"), "/results/empty.json")
+  fun `can perform a match which returns no results as not in that prison`() {
+    search(PrisonSearch(null, null, "smyth", "MDI"), "/results/empty.json")
   }
 
   @Test
   fun `can perform a which returns result for ID search as in correct prison`() {
-    search(SearchCriteria("A7089EY", null, null, "MDI"), "/results/search_results_smith.json")
+    search(PrisonSearch("A7089EY", null, null, "MDI"), "/results/search_results_smith.json")
   }
 
   @Test
   fun `can perform a which returns no results as not in that prison by id`() {
-    search(SearchCriteria("A7089EY", null, null, "LEI"), "/results/empty.json")
+    search(PrisonSearch("A7089EY", null, null, "LEI"), "/results/empty.json")
   }
 
   @Test


### PR DESCRIPTION
This is the first of a couple of PRs to introduce a variant of the `/match` endpoint that takes multiple prison ids to search across (to cater for the use case of searching across all of a user's caseloads for example).

This first PR converts the existing endpoint to use the new search functionality, just as a list of one.