### PR TITLE
DT-1372 Switch to single elasticsearch URL instead of parts

### DIFF
--- a/helm_deploy/prisoner-offender-search/templates/_envs.tpl
+++ b/helm_deploy/prisoner-offender-search/templates/_envs.tpl
@@ -112,4 +112,10 @@ env:
         name: pos-idx-sqs-dl-instance-output
         key: sqs_pos_name
 
+  - name: ELASTICSEARCH_PROXY_URL
+    valueFrom:
+      secretKeyRef:
+        name: elasticsearch
+        key: aws_es_proxy_url
+
 {{- end -}}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/config/ElasticSearchConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/config/ElasticSearchConfiguration.kt
@@ -13,14 +13,11 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @EnableElasticsearchRepositories(basePackages = ["uk.gov.justice.digital.hmpps.prisonersearch.repository"])
 class ElasticSearchConfiguration : AbstractElasticsearchConfiguration() {
 
-  @Value("\${elasticsearch.port}")
-  private val port = 0
-
-  @Value("\${elasticsearch.host}")
-  private val host: String? = null
+  @Value("\${elasticsearch.proxy.url}")
+  private val url: String? = null
 
   @Bean("elasticSearchClient")
   override fun elasticsearchClient(): RestHighLevelClient {
-    return RestClients.create(ClientConfiguration.builder().connectedTo("$host:$port").build()).rest()
+    return RestClients.create(ClientConfiguration.builder().connectedTo("${url?.substringAfter("//")}").build()).rest()
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,9 +9,8 @@ sqs:
     url: http://localhost:4576
 
 elasticsearch:
-  port: 4571
-  scheme: http
-  host: localhost
+  proxy:
+    url: http://localhost:4571
 
 api:
   base:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,9 +90,8 @@ sqs:
       name: prisoner_offender_index_dlq
 
 elasticsearch:
-  port: 9200
-  scheme: http
-  host: aws-es-proxy-service
+  proxy:
+    url: http://aws-es-proxy-service:9200
 
 index:
   page:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/config/LocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/config/LocalStackConfig.kt
@@ -22,7 +22,7 @@ class LocalStackConfig {
   }
 
   @Bean
-  fun localStackContainer(applicationContext: ConfigurableApplicationContext, @Value("\${elasticsearch.proxy.url}") esUrl: String) : LocalStackContainer {
+  fun localStackContainer(applicationContext: ConfigurableApplicationContext, @Value("\${elasticsearch.proxy.url}") esUrl: String): LocalStackContainer {
     log.info("Starting elasticsearch...")
     val elasticsearchContainer = ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:7.6.1")
     elasticsearchContainer

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/config/LocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/config/LocalStackConfig.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.config
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
@@ -21,7 +22,7 @@ class LocalStackConfig {
   }
 
   @Bean
-  fun localStackContainer(applicationContext: ConfigurableApplicationContext): LocalStackContainer {
+  fun localStackContainer(applicationContext: ConfigurableApplicationContext, @Value("\${elasticsearch.proxy.url}") esUrl: String) : LocalStackContainer {
     log.info("Starting elasticsearch...")
     val elasticsearchContainer = ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:7.6.1")
     elasticsearchContainer
@@ -32,7 +33,7 @@ class LocalStackConfig {
 
     val elasticSearchPort = elasticsearchContainer.getMappedPort(9200)
     elasticsearchContainer.setCommand()
-    TestPropertySourceUtils.addInlinedPropertiesToEnvironment(applicationContext, "elasticsearch.port=$elasticSearchPort")
+    TestPropertySourceUtils.addInlinedPropertiesToEnvironment(applicationContext, "elasticsearch.proxy.url=${esUrl.substringBeforeLast(":") + ":$elasticSearchPort"}")
     log.info("Started elasticsearch on port {}", elasticSearchPort)
 
     log.info("Starting localstack...")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,9 +8,8 @@ sqs:
   endpoint.url: http://localhost:4576
 
 elasticsearch:
-  port: 4571
-  scheme: http
-  host: localhost
+  proxy:
+    url: http://localhost:4571
 
 api:
   base:


### PR DESCRIPTION
This is to make it easier to consume the elasticsearch URL Kubernetes secrets