### PR TITLE
DCS-859 Adding resource to allow retrieving prisoners by identifiers.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerSearchResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerSearchResource.kt
@@ -41,10 +41,16 @@ class PrisonerSearchResource(private val prisonerSearchService: PrisonerSearchSe
   fun findByCriteria(@Parameter(required = true) @RequestBody searchCriteria: SearchCriteria) =
     prisonerSearchService.findBySearchCriteria(searchCriteria)
 
+  @Deprecated(message = "Use /ids instead")
   @PostMapping("/prisoner-numbers")
   @Operation(summary = "Match prisoners by a list of prisoner numbers", description = "Requires GLOBAL_SEARCH role")
-  fun findByIds(@Parameter(required = true) @Valid @RequestBody prisonerNumberList: PrisonerListCriteria) =
-    prisonerSearchService.findByListOfPrisonerNumbers(prisonerNumberList)
+  fun findByNumbers(@Parameter(required = true) @Valid @RequestBody criteria: PrisonerListCriteria<Any>) =
+    prisonerSearchService.findBy(criteria)
+
+  @PostMapping("/ids")
+  @Operation(summary = "Match prisoners by a list criteria", description = "Requires GLOBAL_SEARCH role")
+  fun findByIds(@Parameter(required = true) @Valid @RequestBody criteria: PrisonerListCriteria<Any>) =
+    prisonerSearchService.findBy(criteria)
 
   @GetMapping("/prison/{prisonId}")
   @Operation(summary = "Match prisoners by prison", description = "Requires GLOBAL_SEARCH role")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerListCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerListCriteria.kt
@@ -11,6 +11,7 @@ import javax.validation.constraints.Size
 @Schema(
   description = "Search Criteria for a list of prisoners",
   oneOf = [PrisonerNumbers::class, BookingIds::class],
+  discriminatorProperty = "type",
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = PrisonerNumbers::class)
@@ -19,11 +20,7 @@ sealed class PrisonerListCriteria<out T>() {
   abstract fun isValid(): Boolean
   @Schema(hidden = true)
   abstract fun values(): List<T>
-  @Schema(
-    description = "The type of the identifiers, optional but default to 'PrisonerNumbers'",
-    defaultValue = "PrisonerNumbers"
-  )
-  open val type: String = this::class.simpleName!!
+  fun type() = this::class.simpleName!!
 
   @JsonTypeName("PrisonerNumbers")
   data class PrisonerNumbers(
@@ -33,17 +30,16 @@ sealed class PrisonerListCriteria<out T>() {
     val prisonerNumbers: List<String>
   ) : PrisonerListCriteria<String>() {
 
-    @Schema(hidden = true)
     override fun isValid() = prisonerNumbers.isNotEmpty() && prisonerNumbers.size <= 1000
 
-    @Schema(hidden = true)
     override fun values() = prisonerNumbers
 
     @Schema(
-      description = "The type of the identifiers, optional but default to 'PrisonerNumbers'",
+      description = "PrisonerNumbers discriminator value",
+      example = "PrisonerNumbers",
       allowableValues = ["PrisonerNumbers"]
     )
-    override val type: String = this::class.simpleName!!
+    val type: String = type()
   }
 
   @JsonTypeName("BookingIds")
@@ -54,16 +50,15 @@ sealed class PrisonerListCriteria<out T>() {
     val values: List<Long>
   ) : PrisonerListCriteria<Long>() {
 
-    @Schema(hidden = true)
     override fun isValid() = values.isNotEmpty() && values.size <= 1000
 
-    @Schema(hidden = true)
     override fun values() = values
 
     @Schema(
-      description = "The type of the identifiers",
+      description = "BookingIds discriminator value",
+      example = "BookingIds",
       allowableValues = ["BookingIds"]
     )
-    override val type: String = this::class.simpleName!!
+    val type: String = type()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerListCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerListCriteria.kt
@@ -1,17 +1,69 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.services
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonerListCriteria.BookingIds
+import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonerListCriteria.PrisonerNumbers
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.Size
 
-@Schema(description = "Search Criteria for a list of prisoners")
+@Schema(
+  description = "Search Criteria for a list of prisoners",
+  oneOf = [PrisonerNumbers::class, BookingIds::class],
+)
 
-data class PrisonerListCriteria(
-  @Schema(description = "List of prisoner numbers to search by", example = "[\"A1234AA\"]")
-  @NotEmpty
-  @Size(min = 1, max = 1000)
-  val prisonerNumbers: List<String>
-) {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = PrisonerNumbers::class)
+sealed class PrisonerListCriteria<out T>() {
   @Schema(hidden = true)
-  fun isValid() = prisonerNumbers.isNotEmpty() && prisonerNumbers.size <= 1000
+  abstract fun isValid(): Boolean
+  @Schema(hidden = true)
+  abstract fun values(): List<T>
+  @Schema(
+    description = "The type of the identifiers, optional but default to 'PrisonerNumbers'",
+    defaultValue = "PrisonerNumbers"
+  )
+  open val type: String = this::class.simpleName!!
+
+  @JsonTypeName("PrisonerNumbers")
+  data class PrisonerNumbers(
+    @Schema(description = "List of prisoner numbers to search by", example = "[\"A1234AA\"]")
+    @NotEmpty
+    @Size(min = 1, max = 1000)
+    val prisonerNumbers: List<String>
+  ) : PrisonerListCriteria<String>() {
+
+    @Schema(hidden = true)
+    override fun isValid() = prisonerNumbers.isNotEmpty() && prisonerNumbers.size <= 1000
+
+    @Schema(hidden = true)
+    override fun values() = prisonerNumbers
+
+    @Schema(
+      description = "The type of the identifiers, optional but default to 'PrisonerNumbers'",
+      allowableValues = ["PrisonerNumbers"]
+    )
+    override val type: String = this::class.simpleName!!
+  }
+
+  @JsonTypeName("BookingIds")
+  data class BookingIds(
+    @Schema(description = "List of bookingIds to search by", example = "[1, 2, 3]")
+    @NotEmpty
+    @Size(min = 1, max = 1000)
+    val values: List<Long>
+  ) : PrisonerListCriteria<Long>() {
+
+    @Schema(hidden = true)
+    override fun isValid() = values.isNotEmpty() && values.size <= 1000
+
+    @Schema(hidden = true)
+    override fun values() = values
+
+    @Schema(
+      description = "The type of the identifiers",
+      allowableValues = ["BookingIds"]
+    )
+    override val type: String = this::class.simpleName!!
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSearchService.kt
@@ -211,12 +211,12 @@ class PrisonerSearchService(
   fun findBy(criteria: PrisonerListCriteria<Any>): List<Prisoner> {
     with(criteria) {
       if (!isValid()) {
-        log.warn("Invalid search  - no $type provided")
-        throw BadRequestException("Invalid search  - please provide a minimum of 1 and a maximum of 1000 $type")
+        log.warn("Invalid search  - no ${type()} provided")
+        throw BadRequestException("Invalid search  - please provide a minimum of 1 and a maximum of 1000 ${type()}")
       }
 
       queryBy(criteria) { matchByIds(it) } onMatch {
-        customEventForFindBy(type, values().size, it.matches.size)
+        customEventForFindBy(type(), values().size, it.matches.size)
         return it.matches
       }
       return emptyList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/QueueIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/QueueIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonersearch
 
 import com.amazonaws.services.sqs.AmazonSQS
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.google.gson.Gson
@@ -48,6 +49,9 @@ abstract class QueueIntegrationTest : IntegrationTest() {
 
   @Autowired
   lateinit var gson: Gson
+
+  @Autowired
+  lateinit var objectMapper: ObjectMapper
 
   @Autowired
   lateinit var elasticSearchClient: RestHighLevelClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/health/HealthCheckIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/health/HealthCheckIntegrationTest.kt
@@ -125,7 +125,7 @@ class HealthCheckIntegrationTest : IntegrationTest() {
   }
 
   @Test
-  fun `Index Queue does not exist reports down`() {
+  fun `index  queue does not exist reports down`() {
     ReflectionTestUtils.setField(indexQueueHealth, QueueHealth::class.java, "queueName", "missing_queue", String::class.java)
     subPing(200)
 


### PR DESCRIPTION
Used 'oneOf' and discriminators to allow multiple types of requests to same endpoint

Kept backwards compatibility with the old endpoint

Example:
<kbd>
<img width="894" alt="Screenshot 2021-02-12 at 16 00 08" src="https://user-images.githubusercontent.com/1517745/107791161-810cb300-6d4b-11eb-8c43-d0a5e91186b9.png">

</kbd>

Schema:
<kbd>
<img width="850" alt="Screenshot 2021-02-11 at 20 49 36" src="https://user-images.githubusercontent.com/1517745/107697434-1efc7100-6cab-11eb-9949-f7e769ad6ab0.png">

</kbd>
