### PR TITLE
AR-1362: Minor update to use whitespace query analyzer  + tests to verify

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
@@ -146,6 +146,7 @@ class KeywordService(
   ): QueryBuilder {
     return QueryBuilders.multiMatchQuery(term, "*", "aliases.*", "alerts.*")
       // Boost the scores for specific fields so real names and IDs are ranked higher than alias matches
+      .analyzer("whitespace")
       .field("lastName", 10f)
       .field("firstName", 10f)
       .field("prisonerNumber", 10f)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
@@ -166,6 +166,24 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
   }
 
   @Test
+  fun `can perform a keyword AND search on multiple words narrowed down to one prisoner number`() {
+    keywordSearch(
+      keywordRequest = KeywordRequest(andWords = "sam jones A7090AC", prisonIds = listOf("MDI", "AGI", "LEI")),
+      expectedCount = 1,
+      expectedPrisoners = listOf("A7090AC"),
+    )
+  }
+
+  @Test
+  fun `can perform a keyword OR search on multiple words and include an unrelated prisoner number`() {
+    keywordSearch(
+      keywordRequest = KeywordRequest(orWords = "sam jones A7089EZ", prisonIds = listOf("MDI", "AGI", "LEI")),
+      expectedCount = 9,
+      expectedPrisoners = listOf("A7089EZ", "A7090AB", "A7090AC", "A7090AD", "A7090BA", "A7090BB", "A7090BC", "A7090AA", "A7090AF"),
+    )
+  }
+
+  @Test
   fun `can perform a keyword OR search for all male gender prisoners in Moorland`() {
     keywordSearch(
       keywordRequest = KeywordRequest(orWords = "male", prisonIds = listOf("MDI")),


### PR DESCRIPTION
Testing recent changes in dev revealed an issue whereby a series of OR  or AND terms provided along with a specific ID term (like nomsId, or PNC) did not properly recognise or match the ID term - I think because the ID fields are defined as `keyword` types. Adding the `whitespace` analyser to the query had the desired effect as the 2 new tests verify. These were failing without the whitespace analyser.