### PR TITLE
AR-1392: Handling mixed-case search terms + tests to verify

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResource.kt
@@ -34,8 +34,14 @@ class PrisonerDetailResource(private val prisonerDetailService: PrisonerDetailSe
   abstract class PrisonerDetailResponse : Page<Prisoner>
 
   @Operation(
-    summary = "Work in progress - find prisoners by specific field values and return a paginated list matching prisoners",
-    description = "Specify specific field values to match against the indexed values for prisoners. Requires role GLOBAL_SEARCH",
+    summary = "Find prisoners by exact or wildcard terms for specified fields and return a paginated result set",
+    description = """
+      Search terms and identifiers can be provided in either or mixed case and are converted to the appropriate case.
+      This endpoint will find both exact values (full term matched) or wildcards supporting the '*' and '?' symbols.
+      The '*' symbol will match any number of characters e.g. firstName='J*' will match 'John', 'Jane', and 'James'.  
+      The '?' symbol will match any letter substituted at that position. e.g. firstName='t?ny' will match 'Tony' and 'Tiny'
+      Requires role GLOBAL_SEARCH.
+      """,
     security = [SecurityRequirement(name = "GLOBAL_SEARCH")],
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerKeywordResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerKeywordResource.kt
@@ -34,8 +34,12 @@ class PrisonerKeywordResource(private val keywordService: KeywordService) {
   abstract class KeywordResponse : Page<Prisoner>
 
   @Operation(
-    summary = "Work in progress - find prisoners by keywords. It will return the best matching prisoners based on the request",
-    description = "Specify the keywords to match against the indexed text for prisoners. Requires role GLOBAL_SEARCH",
+    summary = "Search for prisoners by keyword or identifiers within a list of prisons and return a paginated result set",
+    description = """ 
+      Words and identifiers can be provided in either or mixed case and will be matched against all indexed text and keyword fields.
+      Identifiers within the [and, or, not, exact] terms are detected and converted to the appropriate case.
+      Requires role GLOBAL_SEARCH.
+      """,
     security = [SecurityRequirement(name = "GLOBAL_SEARCH")],
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
@@ -225,12 +225,12 @@ class KeywordService(
       return tokens
     }
     var newTokens = ""
-    val arrayOfTokens = tokens.split("\\s")
+    val arrayOfTokens = tokens.split("\\s+".toRegex())
     arrayOfTokens.forEach {
       newTokens += if (it.isPrisonerNumber() || it.isCroNumber() || it.isPncNumber()) {
         "${it.uppercase()} "
       } else {
-        "$it "
+        "${it.lowercase()} "
       }
     }
     return newTokens.trim()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerDetailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerDetailService.kt
@@ -91,10 +91,10 @@ class PrisonerDetailService(
       firstName.takeIf { !it.isNullOrBlank() }?.let {
         detailQuery.must(
           QueryBuilders.boolQuery()
-            .should(QueryBuilders.matchQuery("firstName", it).fuzzyTranspositions(fuzzyMatch).boost(5f))
-            .should(QueryBuilders.matchQuery("aliases.firstName", it).fuzzyTranspositions(fuzzyMatch).boost(2f))
-            .should(QueryBuilders.wildcardQuery("firstName", it).boost(5f))
-            .should(QueryBuilders.wildcardQuery("aliases.firstName", it).boost(2f))
+            .should(QueryBuilders.matchQuery("firstName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
+            .should(QueryBuilders.matchQuery("aliases.firstName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(2f))
+            .should(QueryBuilders.wildcardQuery("firstName", it.lowercase()).boost(5f))
+            .should(QueryBuilders.wildcardQuery("aliases.firstName", it.lowercase()).boost(2f))
         )
       }
 
@@ -102,10 +102,10 @@ class PrisonerDetailService(
       lastName.takeIf { !it.isNullOrBlank() }?.let {
         detailQuery.must(
           QueryBuilders.boolQuery()
-            .should(QueryBuilders.matchQuery("lastName", it).fuzzyTranspositions(fuzzyMatch).boost(5f))
-            .should(QueryBuilders.matchQuery("aliases.lastName", it).fuzzyTranspositions(fuzzyMatch).boost(2f))
-            .should(QueryBuilders.wildcardQuery("lastName", it).boost(5f))
-            .should(QueryBuilders.wildcardQuery("aliases.lastName", it).boost(2f))
+            .should(QueryBuilders.matchQuery("lastName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
+            .should(QueryBuilders.matchQuery("aliases.lastName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(2f))
+            .should(QueryBuilders.wildcardQuery("lastName", it.lowercase()).boost(5f))
+            .should(QueryBuilders.wildcardQuery("aliases.lastName", it.lowercase()).boost(2f))
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
@@ -157,6 +157,15 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
   }
 
   @Test
+  fun `can perform a keyword AND search on mixed case names`() {
+    keywordSearch(
+      keywordRequest = KeywordRequest(andWords = "SAm jONes", prisonIds = listOf("MDI", "AGI", "LEI")),
+      expectedCount = 7,
+      expectedPrisoners = listOf("A7090AB", "A7090AC", "A7090AD", "A7090BA", "A7090BB", "A7090BC", "A7090AF"),
+    )
+  }
+
+  @Test
   fun `can perform a keyword AND search on both names in aliases`() {
     keywordSearch(
       keywordRequest = KeywordRequest(andWords = "danny colin", prisonIds = listOf("LEI")),
@@ -205,6 +214,15 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
   fun `can perform a keyword OR search to match last name in alias`() {
     keywordSearch(
       keywordRequest = KeywordRequest(orWords = "cordian", prisonIds = listOf("LEI")),
+      expectedCount = 1,
+      expectedPrisoners = listOf("A7089EZ"),
+    )
+  }
+
+  @Test
+  fun `can perform a keyword OR search to match mixed case last name in alias`() {
+    keywordSearch(
+      keywordRequest = KeywordRequest(orWords = "CORdian", prisonIds = listOf("LEI")),
       expectedCount = 1,
       expectedPrisoners = listOf("A7089EZ"),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
@@ -224,9 +224,27 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
   }
 
   @Test
+  fun `find by mixed case first and last names`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(firstName = "Sam", lastName = "Jones", prisonIds = listOf("MDI", "AGI", "LEI")),
+      expectedCount = 7,
+      expectedPrisoners = listOf("A7090AB", "A7090AC", "A7090AD", "A7090BA", "A7090BB", "A7090BC", "A7090AF"),
+    )
+  }
+
+  @Test
   fun `find by first and last names in alias`() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(firstName = "danny", lastName = "colin", prisonIds = listOf("LEI")),
+      expectedCount = 1,
+      expectedPrisoners = listOf("A7090AF"),
+    )
+  }
+
+  @Test
+  fun `find by mixed case first and last names in alias`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(firstName = "DANny", lastName = "COLin", prisonIds = listOf("LEI")),
       expectedCount = 1,
       expectedPrisoners = listOf("A7090AF"),
     )
@@ -245,6 +263,15 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
   fun `find by main first and last name with single wildcard letters`() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(firstName = "jimb?b", lastName = "j?cks", prisonIds = listOf("LEI")),
+      expectedCount = 1,
+      expectedPrisoners = listOf("A7090AF"),
+    )
+  }
+
+  @Test
+  fun `find by mixed case first and last name with single wildcard letters`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(firstName = "JIMb?b", lastName = "j?cKs", prisonIds = listOf("LEI")),
       expectedCount = 1,
       expectedPrisoners = listOf("A7090AF"),
     )


### PR DESCRIPTION
This PR 

* Fixes a couple of issues with keyword and prisoner-detail searches when mixed-case search terms are presented & introduces some test cases to verify these are now handled ok.  
* Updates the Swagger descriptions for keyword and prisoner detail searches.
* Fixes a bug where search terms were not correctly split for keyword searches.