### PR TITLE
DT-2295 elasticsearch full

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: localstack/localstack-full:0.12.10
         environment:
           - SERVICES=sqs,sns,es
-#          - ES_PORT_EXTERNAL=4571
+          - ES_PORT_EXTERNAL=4571
           - DEBUG=${DEBUG- }
           - DATA_DIR=/tmp/localstack/data
           - DOCKER_HOST=unix:///var/run/docker.sock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,29 @@ version: 2.1
 orbs:
   hmpps: ministryofjustice/hmpps@3.8
 
+executors:
+  validator:
+    docker:
+      - image: cimg/openjdk:16.0
+      - image: localstack/localstack-full:0.12.10
+        environment:
+          - SERVICES=sqs,sns,es
+          - ES_PORT_EXTERNAL=4571
+          - DEBUG=${DEBUG- }
+          - DATA_DIR=/tmp/localstack/data
+          - DOCKER_HOST=unix:///var/run/docker.sock
+          - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+          - AWS_EXECUTION_ENV=True
+          - DEFAULT_REGION=eu-west-2
+          - TMPDIR=/private
+    environment:
+      # Setting max gradle workers to 2 (which means 2 running concurrently, not max 2!) - because although this doesn't stop the ktlint workers from starting it does seem to prevent the test executor from needing as much memory.
+      _JAVA_OPTIONS: -Xmx256m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-XX:+UseContainerSupport -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=2
+    working_directory: ~/app
+
 jobs:
   validate:
-    executor:
-      name: hmpps/localstack
-      jdk_tag: "16.0"
-      services: "sqs,sns,es,elasticsearch"
-      localstack_tag: "0.12.10"
+    executor: validator
     steps:
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: localstack/localstack-full:0.12.10
         environment:
           - SERVICES=sqs,sns,es
-          - ES_PORT_EXTERNAL=4571
+#          - ES_PORT_EXTERNAL=4571
           - DEBUG=${DEBUG- }
           - DATA_DIR=/tmp/localstack/data
           - DOCKER_HOST=unix:///var/run/docker.sock


### PR DESCRIPTION
Use the full localstack image with elasticsearch pre-installed to workaround errors we have seen installing elasticsearch on localstack.