### PR TITLE
PPD-331 - add flag to allow alias search to be disabled

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerDetailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerDetailService.kt
@@ -87,25 +87,37 @@ class PrisonerDetailService(
 
     with(detailRequest) {
 
-      // Match by firstName, exact or by wildcard and include aliases - reduce score for alias matches
+      // Match by firstName, exact or by wildcard and include aliases if set - reduce score for alias matches
       firstName.takeIf { !it.isNullOrBlank() }?.let {
         detailQuery.must(
-          QueryBuilders.boolQuery()
-            .should(QueryBuilders.matchQuery("firstName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
-            .should(QueryBuilders.matchQuery("aliases.firstName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(2f))
-            .should(QueryBuilders.wildcardQuery("firstName", it.lowercase()).boost(5f))
-            .should(QueryBuilders.wildcardQuery("aliases.firstName", it.lowercase()).boost(2f))
+          if (detailRequest.includeAliases) {
+            QueryBuilders.boolQuery()
+              .should(QueryBuilders.matchQuery("firstName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
+              .should(QueryBuilders.matchQuery("aliases.firstName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(2f))
+              .should(QueryBuilders.wildcardQuery("firstName", it.lowercase()).boost(5f))
+              .should(QueryBuilders.wildcardQuery("aliases.firstName", it.lowercase()).boost(2f))
+          } else {
+            QueryBuilders.boolQuery()
+              .should(QueryBuilders.matchQuery("firstName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
+              .should(QueryBuilders.wildcardQuery("firstName", it.lowercase()).boost(5f))
+          }
         )
       }
 
       // Match by lastName, exact or by wildcard match and include aliases - reduce score for alias matches
       lastName.takeIf { !it.isNullOrBlank() }?.let {
         detailQuery.must(
-          QueryBuilders.boolQuery()
-            .should(QueryBuilders.matchQuery("lastName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
-            .should(QueryBuilders.matchQuery("aliases.lastName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(2f))
-            .should(QueryBuilders.wildcardQuery("lastName", it.lowercase()).boost(5f))
-            .should(QueryBuilders.wildcardQuery("aliases.lastName", it.lowercase()).boost(2f))
+          if (detailRequest.includeAliases) {
+            QueryBuilders.boolQuery()
+              .should(QueryBuilders.matchQuery("lastName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
+              .should(QueryBuilders.matchQuery("aliases.lastName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(2f))
+              .should(QueryBuilders.wildcardQuery("lastName", it.lowercase()).boost(5f))
+              .should(QueryBuilders.wildcardQuery("aliases.lastName", it.lowercase()).boost(2f))
+          } else {
+            QueryBuilders.boolQuery()
+              .should(QueryBuilders.matchQuery("lastName", it.lowercase()).fuzzyTranspositions(fuzzyMatch).boost(5f))
+              .should(QueryBuilders.wildcardQuery("lastName", it.lowercase()).boost(5f))
+          }
         )
       }
 
@@ -199,6 +211,7 @@ class PrisonerDetailService(
       "croNumber" to detailRequest.croNumber,
       "fuzzyMatch" to detailRequest.fuzzyMatch.toString(),
       "prisonIds" to detailRequest.prisonIds.toString(),
+      "includeAliases" to detailRequest.includeAliases.toString()
     )
     val metricsMap = mapOf(
       "numberOfResults" to numberOfResults.toDouble()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/dto/PrisonerDetailRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/dto/PrisonerDetailRequest.kt
@@ -51,6 +51,9 @@ data class PrisonerDetailRequest(
   )
   val prisonIds: List<String>? = emptyList(),
 
+  @Schema(description = "Include aliases in search", example = "true", required = false, defaultValue = "true")
+  val includeAliases: Boolean = true,
+
   @Schema(
     description = "Pagination options. Will default to the first page if omitted.",
     required = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
@@ -252,7 +252,7 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(firstName = "Sam", prisonIds = listOf("LEI", "MDI")),
       expectedCount = 4,
-      expectedPrisoners = listOf("A7090AB","A7090BA", "A7090BB","A7090AF"),
+      expectedPrisoners = listOf("A7090AB", "A7090BA", "A7090BB", "A7090AF"),
     )
   }
 
@@ -261,25 +261,25 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(firstName = "Sam", prisonIds = listOf("LEI", "MDI"), includeAliases = false),
       expectedCount = 3,
-      expectedPrisoners = listOf("A7090AB","A7090BA", "A7090BB"),
+      expectedPrisoners = listOf("A7090AB", "A7090BA", "A7090BB"),
     )
   }
 
   @Test
   fun `find by last name including aliases`() {
     detailSearch(
-      detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI","LEI")),
+      detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI", "LEI")),
       expectedCount = 5,
-      expectedPrisoners = listOf("A7090AA","A7090AB","A7090BA","A7090BB","A7090AF"),
+      expectedPrisoners = listOf("A7090AA", "A7090AB", "A7090BA", "A7090BB", "A7090AF"),
     )
   }
 
   @Test
   fun `find by last name excluding aliases`() {
     detailSearch(
-      detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI","LEI"), includeAliases = false),
+      detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI", "LEI"), includeAliases = false),
       expectedCount = 4,
-      expectedPrisoners = listOf("A7090AA","A7090AB","A7090BA","A7090BB"),
+      expectedPrisoners = listOf("A7090AA", "A7090AB", "A7090BA", "A7090BB"),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
@@ -248,11 +248,56 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
   }
 
   @Test
+  fun `find by first name including aliases`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(firstName = "Sam", prisonIds = listOf("LEI", "MDI")),
+      expectedCount = 4,
+      expectedPrisoners = listOf("A7090AB","A7090BA", "A7090BB","A7090AF"),
+    )
+  }
+
+  @Test
+  fun `find by first name excluding aliases`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(firstName = "Sam", prisonIds = listOf("LEI", "MDI"), includeAliases = false),
+      expectedCount = 3,
+      expectedPrisoners = listOf("A7090AB","A7090BA", "A7090BB"),
+    )
+  }
+
+  @Test
+  fun `find by last name including aliases`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI","LEI")),
+      expectedCount = 5,
+      expectedPrisoners = listOf("A7090AA","A7090AB","A7090BA","A7090BB","A7090AF"),
+    )
+  }
+
+  @Test
+  fun `find by last name excluding aliases`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI","LEI"), includeAliases = false),
+      expectedCount = 4,
+      expectedPrisoners = listOf("A7090AA","A7090AB","A7090BA","A7090BB"),
+    )
+  }
+
+  @Test
   fun `find by first and last names`() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(firstName = "sam", lastName = "jones", prisonIds = listOf("MDI", "AGI", "LEI")),
       expectedCount = 7,
       expectedPrisoners = listOf("A7090AB", "A7090AC", "A7090AD", "A7090BA", "A7090BB", "A7090BC", "A7090AF"),
+    )
+  }
+
+  @Test
+  fun `find by first and last names excluding aliases`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(firstName = "sam", lastName = "jones", prisonIds = listOf("MDI", "AGI", "LEI"), includeAliases = false),
+      expectedCount = 6,
+      expectedPrisoners = listOf("A7090AB", "A7090AC", "A7090AD", "A7090BA", "A7090BB", "A7090BC"),
     )
   }
 


### PR DESCRIPTION
Existing prisoner detail search will continue to search across prisoner aliases when searching on first name or last name however this new optional attribute will allow this alias check to be disabled.