### PR TITLE
DT-2959: pinned spring-data-elasticsearch to 4.2.7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
   implementation("org.springframework.boot:spring-boot-starter-actuator")
-  implementation("org.springframework.data:spring-data-elasticsearch")
+  implementation("org.springframework.data:spring-data-elasticsearch:4.2.7")
 
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")


### PR DESCRIPTION
Currently unable to use rest-high-level-client:7.15.2 which come in spring-data-elasticsearch:4.3.0
AWS currently only support elasticsearch to 7.10
https://github.com/elastic/elasticsearch/issues/76091#issuecomment-892817267