### PR TITLE
DT-2959: pinned elasticsearch version 7.12.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,13 @@ dependencyCheck {
   suppressionFiles.add("elasticsearch-suppressions.xml")
 }
 
+// pinned elasticsearch version to 7.12.1 and spring-data-elasticsearch:4.2.7
+// rest-high-level-client:7.15.2 is not compatible with our current version of elasticsearch
+// (AWS currently only support elasticsearch to 7.10)
+// https://github.com/elastic/elasticsearch/issues/76091#issuecomment-892817267
+
+ext["elasticsearch.version"] = "7.12.1"
+
 dependencies {
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
@@ -4,7 +4,7 @@ import com.google.gson.Gson
 import com.microsoft.applicationinsights.TelemetryClient
 import org.elasticsearch.action.search.SearchRequest
 import org.elasticsearch.action.search.SearchResponse
-import org.elasticsearch.core.TimeValue
+import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.index.query.BoolQueryBuilder
 import org.elasticsearch.index.query.MultiMatchQueryBuilder
 import org.elasticsearch.index.query.Operator

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerDetailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerDetailService.kt
@@ -4,7 +4,7 @@ import com.google.gson.Gson
 import com.microsoft.applicationinsights.TelemetryClient
 import org.elasticsearch.action.search.SearchRequest
 import org.elasticsearch.action.search.SearchResponse
-import org.elasticsearch.core.TimeValue
+import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.index.query.BoolQueryBuilder
 import org.elasticsearch.index.query.QueryBuilders
 import org.elasticsearch.search.builder.SearchSourceBuilder


### PR DESCRIPTION
Currently unable to use rest-high-level-client:7.15.2 which come in spring-data-elasticsearch:4.3.0
AWS currently only support elasticsearch to 7.10
https://github.com/elastic/elasticsearch/issues/76091#issuecomment-892817267