### PR TITLE
SDI-243 ESTABLISHMENT mode for key word sort

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.prisonersearch.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.data.annotation.Id
-import org.springframework.data.elasticsearch.annotations.*
+import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.InnerField
+import org.springframework.data.elasticsearch.annotations.MultiField
 import java.time.LocalDate
 
 open class Prisoner {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -2,10 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.data.annotation.Id
-import org.springframework.data.elasticsearch.annotations.DateFormat
-import org.springframework.data.elasticsearch.annotations.Document
-import org.springframework.data.elasticsearch.annotations.Field
-import org.springframework.data.elasticsearch.annotations.FieldType
+import org.springframework.data.elasticsearch.annotations.*
 import java.time.LocalDate
 
 open class Prisoner {
@@ -38,12 +35,24 @@ open class Prisoner {
   @Schema(description = "Book Number", example = "38412A")
   var bookNumber: String? = null
 
+  @MultiField(
+    mainField = Field(type = FieldType.Text),
+    otherFields = [
+      InnerField(type = FieldType.Keyword, suffix = "keyword")
+    ]
+  )
   @Schema(required = true, description = "First Name", example = "Robert")
   var firstName: String? = null
 
   @Schema(description = "Middle Names", example = "John James")
   var middleNames: String? = null
 
+  @MultiField(
+    mainField = Field(type = FieldType.Text),
+    otherFields = [
+      InnerField(type = FieldType.Keyword, suffix = "keyword")
+    ]
+  )
   @Schema(required = true, description = "Last name", example = "Larsen")
   var lastName: String? = null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.prisonersearch.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.data.annotation.Id
+import org.springframework.data.elasticsearch.annotations.DateFormat
+import org.springframework.data.elasticsearch.annotations.Document
 import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.data.elasticsearch.annotations.InnerField
 import org.springframework.data.elasticsearch.annotations.MultiField
 import java.time.LocalDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/KeywordService.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.model.Prisoner
 import uk.gov.justice.digital.hmpps.prisonersearch.security.AuthenticationHolder
 import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.KeywordRequest
 import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.PaginationRequest
+import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.SearchType
 import uk.gov.justice.digital.hmpps.prisonersearch.services.exceptions.BadRequestException
 import java.util.concurrent.TimeUnit
 
@@ -72,10 +73,19 @@ class KeywordService(
       timeout(TimeValue(searchTimeoutSeconds, TimeUnit.SECONDS))
       size(pageable.pageSize.coerceAtMost(maxSearchResults))
       from(pageable.offset.toInt())
-      sort("_score")
-      sort("prisonerNumber")
       trackTotalHits(true)
       query(buildKeywordQuery(keywordRequest))
+      when (keywordRequest.type) {
+        SearchType.DEFAULT -> {
+          sort("_score")
+          sort("prisonerNumber")
+        }
+        SearchType.ESTABLISHMENT -> {
+          sort("lastName.keyword")
+          sort("firstName.keyword")
+          sort("prisonerNumber")
+        }
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/dto/KeywordRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/dto/KeywordRequest.kt
@@ -50,4 +50,16 @@ data class KeywordRequest(
     required = false,
   )
   val pagination: PaginationRequest = PaginationRequest(0, 10),
-)
+
+  @Schema(
+    description = "The type of search. An ESTABLISHMENT type will order results by name and is designed for using this API for a single quick search field for prisoners within a specific prison",
+    required = false,
+  )
+  val type: SearchType = SearchType.DEFAULT,
+
+  )
+
+enum class SearchType {
+  DEFAULT,
+  ESTABLISHMENT
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/dto/KeywordRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/dto/KeywordRequest.kt
@@ -57,7 +57,7 @@ data class KeywordRequest(
   )
   val type: SearchType = SearchType.DEFAULT,
 
-  )
+)
 
 enum class SearchType {
   DEFAULT,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/MessageIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/MessageIntegrationTest.kt
@@ -160,7 +160,7 @@ class MessageIntegrationTest : QueueIntegrationTest() {
       .expectBody()
       .jsonPath("index-status.currentIndex").isEqualTo(SyncIndex.INDEX_B.name)
       .jsonPath("index-status.inProgress").isEqualTo("true")
-      .jsonPath("index-size.${SyncIndex.INDEX_A.name}").isEqualTo("24")
+      .jsonPath("index-size.${SyncIndex.INDEX_A.name}").isEqualTo("25")
 
     search(SearchCriteria("A7089FE", null, null), "/results/search_results_A7089FE.json")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/MessageIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/MessageIntegrationTest.kt
@@ -139,7 +139,7 @@ class MessageIntegrationTest : QueueIntegrationTest() {
       .expectBody()
       .jsonPath("index-status.currentIndex").isEqualTo(SyncIndex.INDEX_B.name)
       .jsonPath("index-status.inProgress").isEqualTo("true")
-      .jsonPath("index-size.${SyncIndex.INDEX_A.name}").isEqualTo("23")
+      .jsonPath("index-size.${SyncIndex.INDEX_A.name}").isEqualTo("24")
 
     val message = "/messages/offenderDetailsNew.json".readResourceAsText()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/QueueIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/QueueIntegrationTest.kt
@@ -107,6 +107,7 @@ abstract class QueueIntegrationTest : IntegrationTest() {
     await untilCallTo { prisonRequestCountFor("/api/offenders/A9999RA") } matches { it == 1 }
     await untilCallTo { prisonRequestCountFor("/api/offenders/A9999RB") } matches { it == 1 }
     await untilCallTo { prisonRequestCountFor("/api/offenders/A9999RC") } matches { it == 1 }
+    await untilCallTo { prisonRequestCountFor("/api/offenders/A1090AA") } matches { it == 1 }
 
     await untilCallTo { getNumberOfMessagesCurrentlyOnIndexQueue() } matches { it == 0 }
     Thread.sleep(500)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.prisonersearch.QueueIntegrationTest
 import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.KeywordRequest
+import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.SearchType
 
 class KeywordSearchResourceTest : QueueIntegrationTest() {
 
@@ -196,6 +197,52 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
   }
 
   @Test
+  fun `default order is by score, prison number`() {
+    keywordSearch(
+      keywordRequest = KeywordRequest(
+        andWords = "jones",
+        prisonIds = listOf("MDI", "AGI", "LEI"),
+        type = SearchType.DEFAULT
+      ),
+      expectedCount = 9,
+      expectedPrisoners = listOf(
+        "A1090AA",
+        "A7090AB",
+        "A7090AC",
+        "A7090AD",
+        "A7090BA",
+        "A7090BB",
+        "A7090BC",
+        "A7090AF",
+        "A7090AA"
+      ),
+    )
+  }
+
+  @Test
+  fun `establishment order is by name`() {
+    keywordSearch(
+      keywordRequest = KeywordRequest(
+        andWords = "jones",
+        prisonIds = listOf("MDI", "AGI", "LEI"),
+        type = SearchType.ESTABLISHMENT
+      ),
+      expectedCount = 9,
+      expectedPrisoners = listOf(
+        "A7090AA", // JONES, ERIC
+        "A7090AB", // JONES, SAM
+        "A7090AC", // JONES, SAM
+        "A7090AD", // JONES, SAM
+        "A7090BA", // JONES, SAM
+        "A7090BB", // JONES, SAM
+        "A7090BC", // JONES, SAM
+        "A7090AF", // JONES, SAM
+        "A1090AA"  // JONES, ZAC
+      ),
+    )
+  }
+
+  @Test
   fun `can perform a keyword AND search on both names in aliases`() {
     keywordSearch(
       keywordRequest = KeywordRequest(andWords = "danny colin", prisonIds = listOf("LEI")),
@@ -217,8 +264,19 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
   fun `can perform a keyword OR search on multiple words and include an unrelated prisoner number`() {
     keywordSearch(
       keywordRequest = KeywordRequest(orWords = "sam jones A7089EZ", prisonIds = listOf("MDI", "AGI", "LEI")),
-      expectedCount = 9,
-      expectedPrisoners = listOf("A7089EZ", "A7090AB", "A7090AC", "A7090AD", "A7090BA", "A7090BB", "A7090BC", "A7090AA", "A7090AF"),
+      expectedCount = 10,
+      expectedPrisoners = listOf(
+        "A1090AA",
+        "A7089EZ",
+        "A7090AB",
+        "A7090AC",
+        "A7090AD",
+        "A7090BA",
+        "A7090BB",
+        "A7090BC",
+        "A7090AA",
+        "A7090AF"
+      ),
     )
   }
 
@@ -226,8 +284,8 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
   fun `can perform a keyword OR search for all male gender prisoners in Moorland`() {
     keywordSearch(
       keywordRequest = KeywordRequest(orWords = "male", prisonIds = listOf("MDI")),
-      expectedCount = 6,
-      expectedPrisoners = listOf("A7089EY", "A7089FA", "A7089FB", "A7090AA", "A7090AB", "A7090BB"),
+      expectedCount = 7,
+      expectedPrisoners = listOf("A1090AA", "A7089EY", "A7089FA", "A7089FB", "A7090AA", "A7090AB", "A7090BB"),
     )
   }
 
@@ -298,8 +356,8 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
   fun `can perform a keyword no-terms query to match all prisoners in one location`() {
     keywordSearch(
       keywordRequest = KeywordRequest(prisonIds = listOf("MDI")),
-      expectedCount = 6,
-      expectedPrisoners = listOf("A7089EY", "A7089FA", "A7089FB", "A7090AA", "A7090AB", "A7090BB"),
+      expectedCount = 7,
+      expectedPrisoners = listOf("A1090AA", "A7089EY", "A7089FA", "A7089FB", "A7090AA", "A7090AB", "A7090BB"),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/KeywordSearchResourceTest.kt
@@ -237,7 +237,7 @@ class KeywordSearchResourceTest : QueueIntegrationTest() {
         "A7090BB", // JONES, SAM
         "A7090BC", // JONES, SAM
         "A7090AF", // JONES, SAM
-        "A1090AA"  // JONES, ZAC
+        "A1090AA" // JONES, ZAC
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerDetailResourceTest.kt
@@ -269,8 +269,8 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
   fun `find by last name including aliases`() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI", "LEI")),
-      expectedCount = 5,
-      expectedPrisoners = listOf("A7090AA", "A7090AB", "A7090BA", "A7090BB", "A7090AF"),
+      expectedCount = 6,
+      expectedPrisoners = listOf("A7090AA", "A7090AB", "A7090BA", "A7090BB", "A7090AF", "A1090AA"),
     )
   }
 
@@ -278,8 +278,8 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
   fun `find by last name excluding aliases`() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(lastName = "Jones", prisonIds = listOf("MDI", "LEI"), includeAliases = false),
-      expectedCount = 4,
-      expectedPrisoners = listOf("A7090AA", "A7090AB", "A7090BA", "A7090BB"),
+      expectedCount = 5,
+      expectedPrisoners = listOf("A7090AA", "A7090AB", "A7090BA", "A7090BB", "A1090AA"),
     )
   }
 
@@ -359,8 +359,8 @@ class PrisonerDetailResourceTest : QueueIntegrationTest() {
   fun `no-terms query should match all prisoners in the specified location`() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(prisonIds = listOf("MDI")),
-      expectedCount = 6,
-      expectedPrisoners = listOf("A7089EY", "A7089FA", "A7089FB", "A7090AA", "A7090AB", "A7090BB"),
+      expectedCount = 7,
+      expectedPrisoners = listOf("A7089EY", "A7089FA", "A7089FB", "A7090AA", "A7090AB", "A7090BB", "A1090AA"),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerIndexResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/PrisonerIndexResourceTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.services.IndexQueueStatus
 
 class PrisonerIndexResourceTest : QueueIntegrationTest() {
 
-  private val indexCount = 23
+  private val indexCount = 24
 
   @BeforeEach
   fun init() {

--- a/src/test/resources/mappings/getBooking_A1090AA.json
+++ b/src/test/resources/mappings/getBooking_A1090AA.json
@@ -1,0 +1,55 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/offenders/A1090AA"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "bookingId": 1903838,
+      "bookingNo": "V63588",
+      "offenderNo": "A1090AA",
+      "firstName": "ZACK",
+      "lastName": "JONES",
+      "agencyId": "MDI",
+      "activeFlag": true,
+      "assignedLivingUnit": {
+        "agencyId": "MDI",
+        "description": "H-1-004",
+        "agencyName": "Moorland Prison"
+      },
+      "facialImageId": 1171177,
+      "dateOfBirth": "1980-02-28",
+      "physicalAttributes": {
+        "gender": "Male",
+        "raceCode": "W1",
+        "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+        "sexCode": "M"
+      },
+      "physicalCharacteristics": [
+        {
+          "type": "SHOESIZE",
+          "characteristic": "Shoe Size",
+          "detail": "10"
+        }
+      ],
+      "profileInformation": [
+        {
+          "type": "RELF",
+          "question": "Religion",
+          "resultValue": "Christian"
+        }
+      ],
+      "inOutStatus": "IN",
+      "lastMovementTypeCode": "ADM",
+      "lastMovementReasonCode": "24",
+      "identifiers": [
+      ],
+      "status": "ACTIVE IN",
+      "legalStatus": "RECALL"
+    }
+  }
+}

--- a/src/test/resources/mappings/getIds_page9.json
+++ b/src/test/resources/mappings/getIds_page9.json
@@ -4,10 +4,10 @@
     "urlPath": "/api/offenders/ids",
     "headers" : {
       "Page-Offset": {
-        "equalTo": "0"
+        "equalTo": "24"
       },
       "Page-Limit": {
-        "equalTo": "1"
+        "equalTo": "3"
       }
     }
   },
@@ -15,11 +15,11 @@
     "status": 200,
     "headers": {
       "Content-Type": "application/json",
-      "Total-Records": "25"
+      "Total-Records": "20"
     },
     "jsonBody": [
       {
-        "offenderNumber": "A7089EY"
+        "offenderNumber": "A1090AA"
       }
     ]
   }

--- a/src/test/resources/results/search_results_mdi.json
+++ b/src/test/resources/results/search_results_mdi.json
@@ -1,6 +1,27 @@
 {
   "content":[
     {
+      "prisonerNumber": "A1090AA",
+      "bookingId": "1903838",
+      "bookNumber": "V63588",
+      "firstName": "ZACK",
+      "lastName": "JONES",
+      "dateOfBirth": "1980-02-28",
+      "gender": "Male",
+      "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+      "youthOffender": false,
+      "religion": "Christian",
+      "status": "ACTIVE IN",
+      "lastMovementTypeCode": "ADM",
+      "lastMovementReasonCode": "24",
+      "inOutStatus": "IN",
+      "prisonId": "MDI",
+      "prisonName": "Moorland Prison",
+      "cellLocation": "H-1-004",
+      "legalStatus": "RECALL",
+      "restrictedPatient": false
+    },
+    {
       "prisonerNumber":"A7089EY",
       "pncNumber":"12/394773H",
       "pncNumberCanonicalShort":"12/394773H",
@@ -316,7 +337,7 @@
     "unpaged":false
   },
   "last":true,
-  "totalElements":8,
+  "totalElements":9,
   "totalPages":1,
   "size":10,
   "number":0,
@@ -325,7 +346,7 @@
     "unsorted":true,
     "empty":true
   },
-  "numberOfElements":8,
+  "numberOfElements":9,
   "first":true,
   "empty":false
 }

--- a/src/test/resources/results/search_results_mdi_pagination1.json
+++ b/src/test/resources/results/search_results_mdi_pagination1.json
@@ -1,25 +1,23 @@
 {
   "content": [
     {
-      "prisonerNumber": "A7089FA",
-      "pncNumber": "12/394773I",
-      "croNumber": "29906/12K",
-      "bookingId": "2900837",
-      "bookNumber": "V61586",
-      "firstName": "JAMES",
-      "middleNames": "TREVOR",
-      "lastName": "DAVIES",
-      "dateOfBirth": "1990-01-31",
+      "prisonerNumber": "A7089EY",
+      "pncNumber": "12/394773H",
+      "croNumber": "29906/12J",
+      "bookingId": "1900836",
+      "bookNumber": "V61585",
+      "firstName": "JOHN",
+      "middleNames": "LEE",
+      "lastName": "SMITH",
+      "dateOfBirth": "1980-12-31",
       "gender": "Male",
       "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
-      "youthOffender": false,
+      "youthOffender": true,
       "religion": "Christian",
       "nationality": "British",
       "status": "ACTIVE IN",
       "prisonId": "MDI",
-      "prisonName": "Moorland Prison",
-      "cellLocation": "A-1-002",
-      "legalStatus": "REMAND"
+      "prisonName": "Moorland Prison"
     }
   ],
   "pageable": {
@@ -34,8 +32,8 @@
     "paged": true,
     "unpaged": false
   },
-  "totalPages": 6,
-  "totalElements": 6,
+  "totalElements": 7,
+  "totalPages": 7,
   "last": false,
   "number": 1,
   "size": 1,

--- a/src/test/resources/results/search_results_mdi_pagination2.json
+++ b/src/test/resources/results/search_results_mdi_pagination2.json
@@ -1,6 +1,27 @@
 {
   "content": [
     {
+      "prisonerNumber": "A7090AA",
+      "pncNumber": "12/394773I",
+      "pncNumberCanonicalShort": "12/394773I",
+      "pncNumberCanonicalLong": "2012/394773I",
+      "croNumber": "29906/12P",
+      "bookingId": "1903838",
+      "bookNumber": "V63588",
+      "firstName": "ERIC",
+      "lastName": "JONES",
+      "dateOfBirth": "1980-02-28",
+      "gender": "Male",
+      "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+      "youthOffender": false,
+      "religion": "Christian",
+      "status": "ACTIVE IN",
+      "prisonId": "MDI",
+      "prisonName": "Moorland Prison",
+      "cellLocation": "H-1-004",
+      "legalStatus": "REMAND"
+    },
+    {
       "prisonerNumber": "A7090AB",
       "pncNumber": "12/394773I",
       "croNumber": "29906/12P",
@@ -18,26 +39,6 @@
       "prisonName": "Moorland Prison",
       "cellLocation": "H-1-004",
       "legalStatus": "REMAND"
-    },
-    {
-      "prisonerNumber": "A7090BB",
-      "pncNumber": "12/394773W",
-      "croNumber": "29906/12L",
-      "bookingId": "1904838",
-      "bookNumber": "V61587",
-      "firstName": "SAM",
-      "lastName": "JONES",
-      "dateOfBirth": "1962-11-01",
-      "gender": "Male",
-      "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
-      "youthOffender": false,
-      "religion": "Christian",
-      "nationality": "British",
-      "status": "ACTIVE IN",
-      "prisonId": "MDI",
-      "prisonName": "Moorland Prison",
-      "cellLocation": "A-1-003",
-      "legalStatus": "REMAND"
     }
   ],
   "pageable": {
@@ -52,9 +53,9 @@
     "paged": true,
     "unpaged": false
   },
-  "totalPages": 3,
-  "totalElements": 6,
-  "last": true,
+  "totalPages": 4,
+  "totalElements": 7,
+  "last": false,
   "number": 2,
   "size": 2,
   "numberOfElements": 2,


### PR DESCRIPTION
Change allows an addition `type` parameter to override the sort behaviour for a `keyword` search.

Change requires a reindex since firstName and lastName now need to be indexed as keywords (so ES can only sort on keywords) as well as the previous text.

Changes is much larger then is desired because added an additional prisoner which then breaks LOADS of tests.
A future change will improve this.