### PR TITLE
SDI-301 Improved auditing and ignored common punctuation

### DIFF
--- a/docker-compose-localstack-tests.yml
+++ b/docker-compose-localstack-tests.yml
@@ -15,6 +15,7 @@ services:
       - DOCKER_HOST=unix:///var/run/docker.sock
       - DEFAULT_REGION=eu-west-2
     volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
       - $PWD/src/test/resources/localstack:/docker-entrypoint-initaws.d
 networks:


### PR DESCRIPTION
1. Users often leave a comma in the search term `marke, andy` - fix that not returning any searches
2. Output of parameters to application insights 