### PR TITLE
SDI-287 Create difference engine for Prisoner

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -108,11 +108,11 @@ open class Prisoner : Diffable<Prisoner> {
   var status: String? = null
 
   @Schema(description = "Last Movement Type Code of prisoner", example = "CRT")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(PropertyType.LOCATION)
   var lastMovementTypeCode: String? = null
 
   @Schema(description = "Last Movement Reason of prisoner", example = "CA")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(PropertyType.LOCATION)
   var lastMovementReasonCode: String? = null
 
   @Schema(description = "In/Out Status", example = "IN", allowableValues = ["IN", "OUT"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -134,7 +134,7 @@ open class Prisoner : Diffable<Prisoner> {
 
   @Field(type = FieldType.Nested, includeInParent = true)
   @Schema(description = "Aliases Names and Details")
-  @DiffableType(DiffType.LOCATION)
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var aliases: List<PrisonerAlias>? = null
 
   @Field(type = FieldType.Nested, includeInParent = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -10,9 +10,9 @@ import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.data.elasticsearch.annotations.InnerField
 import org.springframework.data.elasticsearch.annotations.MultiField
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffType
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffableType
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.getDiff
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffableProperty
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PropertyType
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.getDiffResult
 import java.time.LocalDate
 
 open class Prisoner : Diffable<Prisoner> {
@@ -23,7 +23,7 @@ open class Prisoner : Diffable<Prisoner> {
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "PNC Number", example = "12/394773H")
-  @DiffableType(DiffType.IDENTIFIERS)
+  @DiffableProperty(PropertyType.IDENTIFIERS)
   var pncNumber: String? = null
 
   @Field(type = FieldType.Keyword)
@@ -36,17 +36,17 @@ open class Prisoner : Diffable<Prisoner> {
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "CRO Number", example = "29906/12J")
-  @DiffableType(DiffType.IDENTIFIERS)
+  @DiffableProperty(PropertyType.IDENTIFIERS)
   var croNumber: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Booking No.", example = "0001200924")
-  @DiffableType(DiffType.IDENTIFIERS)
+  @DiffableProperty(PropertyType.IDENTIFIERS)
   var bookingId: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Book Number", example = "38412A")
-  @DiffableType(DiffType.IDENTIFIERS)
+  @DiffableProperty(PropertyType.IDENTIFIERS)
   var bookNumber: String? = null
 
   @MultiField(
@@ -56,11 +56,11 @@ open class Prisoner : Diffable<Prisoner> {
     ]
   )
   @Schema(required = true, description = "First Name", example = "Robert")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var firstName: String? = null
 
   @Schema(description = "Middle Names", example = "John James")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var middleNames: String? = null
 
   @MultiField(
@@ -70,84 +70,84 @@ open class Prisoner : Diffable<Prisoner> {
     ]
   )
   @Schema(required = true, description = "Last name", example = "Larsen")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var lastName: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(required = true, description = "Date of Birth", example = "1975-04-02")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var dateOfBirth: LocalDate? = null
 
   @Schema(required = true, description = "Gender", example = "Female")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var gender: String? = null
 
   @Schema(required = true, description = "Ethnicity", example = "White: Eng./Welsh/Scot./N.Irish/British")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var ethnicity: String? = null
 
   @Schema(required = true, description = "Youth Offender?", example = "true")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var youthOffender: Boolean? = null
 
   @Schema(required = true, description = "Marital Status", example = "Widowed")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var maritalStatus: String? = null
 
   @Schema(required = true, description = "Religion", example = "Church of England (Anglican)")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var religion: String? = null
 
   @Schema(required = true, description = "Nationality", example = "Egyptian")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var nationality: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(required = true, description = "Status of the prisoner", example = "ACTIVE IN")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var status: String? = null
 
   @Schema(description = "Last Movement Type Code of prisoner", example = "CRT")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var lastMovementTypeCode: String? = null
 
   @Schema(description = "Last Movement Reason of prisoner", example = "CA")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var lastMovementReasonCode: String? = null
 
   @Schema(description = "In/Out Status", example = "IN", allowableValues = ["IN", "OUT"])
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var inOutStatus: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Prison ID", example = "MDI")
-  @DiffableType(DiffType.LOCATION)
+  @DiffableProperty(PropertyType.LOCATION)
   var prisonId: String? = null
 
   @Schema(description = "Prison Name", example = "HMP Leeds")
-  @DiffableType(DiffType.LOCATION)
+  @DiffableProperty(PropertyType.LOCATION)
   var prisonName: String? = null
 
   @Schema(description = "In prison cell location", example = "A-1-002")
-  @DiffableType(DiffType.LOCATION)
+  @DiffableProperty(PropertyType.LOCATION)
   var cellLocation: String? = null
 
   @Field(type = FieldType.Nested, includeInParent = true)
   @Schema(description = "Aliases Names and Details")
-  @DiffableType(DiffType.PERSONAL_DETAILS)
+  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
   var aliases: List<PrisonerAlias>? = null
 
   @Field(type = FieldType.Nested, includeInParent = true)
   @Schema(description = "Alerts")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var alerts: List<PrisonerAlert>? = null
 
   @Schema(description = "Cell Sharing Risk Assessment", example = "HIGH")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var csra: String? = null
 
   @Schema(description = "Prisoner Category", example = "C")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var category: String? = null
 
   @Schema(
@@ -155,81 +155,81 @@ open class Prisoner : Diffable<Prisoner> {
     example = "SENTENCED",
     allowableValues = ["RECALL", "DEAD", "INDETERMINATE_SENTENCE", "SENTENCED", "CONVICTED_UNSENTENCED", "CIVIL_PRISONER", "IMMIGRATION_DETAINEE", "REMAND", "UNKNOWN", "OTHER"]
   )
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var legalStatus: String? = null
 
   @Schema(description = "The prisoner's imprisonment status code.", example = "LIFE")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var imprisonmentStatus: String? = null
 
   @Schema(description = "The prisoner's imprisonment status description.", example = "Serving Life Imprisonment")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var imprisonmentStatusDescription: String? = null
 
   @Schema(required = true, description = "Most serious offence for this sentence", example = "Robbery")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var mostSeriousOffence: String? = null
 
   @Schema(description = "Indicates that the offender has been recalled", example = "false")
-  @DiffableType(DiffType.STATUS)
+  @DiffableProperty(PropertyType.STATUS)
   var recall: Boolean? = null
 
   @Schema(description = "Indicates the the offender has an indeterminate sentence", example = "true")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var indeterminateSentence: Boolean? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Start Date for this sentence", example = "2020-04-03")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var sentenceStartDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Actual of most likely Release Date", example = "2023-05-02")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var releaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Release Date Confirmed", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var confirmedReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Sentence Expiry Date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var sentenceExpiryDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Licence Expiry Date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var licenceExpiryDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC Eligibility Date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var homeDetentionCurfewEligibilityDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC Actual Date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var homeDetentionCurfewActualDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC End Date", example = "2023-05-02")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var homeDetentionCurfewEndDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Top-up supervision start date", example = "2023-04-29")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var topupSupervisionStartDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Top-up supervision expiry date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var topupSupervisionExpiryDate: LocalDate? = null
 
   @Schema(description = "Days added to sentence term due to adjustments.", example = "10")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var additionalDaysAwarded: Int? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
@@ -237,7 +237,7 @@ open class Prisoner : Diffable<Prisoner> {
     description = "Release date for Non determinant sentence (if applicable). This will be based on one of ARD, CRD, NPD or PRRD.",
     example = "2023-05-01"
   )
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var nonDtoReleaseDate: LocalDate? = null
 
   @Schema(
@@ -245,76 +245,76 @@ open class Prisoner : Diffable<Prisoner> {
     example = "ARD",
     allowableValues = ["ARD", "CRD", "NPD", "PRRD"]
   )
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var nonDtoReleaseDateType: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date prisoner was received into the prison", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var receptionDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Parole  Eligibility Date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var paroleEligibilityDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Automatic Release Date. If automaticReleaseOverrideDate is available then it will be set as automaticReleaseDate", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var automaticReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Post Recall Release Date. if postRecallReleaseOverrideDate is available then it will be set as postRecallReleaseDate", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var postRecallReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Conditional Release Date. If conditionalReleaseOverrideDate is available then it will be set as conditionalReleaseDate", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var conditionalReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Actual Parole Date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var actualParoleDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Tariff Date", example = "2023-05-01")
-  @DiffableType(DiffType.SENTENCE)
+  @DiffableProperty(PropertyType.SENTENCE)
   var tariffDate: LocalDate? = null
 
   @Schema(
     description = "current prison or outside with last movement information.",
     example = "Outside - released from Leeds"
   )
-  @DiffableType(DiffType.LOCATION)
+  @DiffableProperty(PropertyType.LOCATION)
   var locationDescription: String? = null
 
   @Schema(required = true, description = "Indicates a restricted patient", example = "true")
-  @DiffableType(DiffType.RESTRICTED_PATIENT)
+  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
   var restrictedPatient: Boolean = false
 
   @Schema(description = "Supporting prison ID for POM", example = "LEI")
-  @DiffableType(DiffType.RESTRICTED_PATIENT)
+  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
   var supportingPrisonId: String? = null
 
   @Schema(description = "Which hospital the offender has been discharged to", example = "HAZLWD")
-  @DiffableType(DiffType.RESTRICTED_PATIENT)
+  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
   var dischargedHospitalId: String? = null
 
   @Schema(description = "Hospital name to which the offender was discharged", example = "Hazelwood House")
-  @DiffableType(DiffType.RESTRICTED_PATIENT)
+  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
   var dischargedHospitalDescription: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date of discharge", example = "2020-05-01")
-  @DiffableType(DiffType.RESTRICTED_PATIENT)
+  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
   var dischargeDate: LocalDate? = null
 
   @Schema(description = "Any additional discharge details", example = "Psychiatric Hospital Discharge to Hazelwood House")
   var dischargeDetails: String? = null
 
-  override fun diff(other: Prisoner): DiffResult<Prisoner> = getDiff(this, other)
+  override fun diff(other: Prisoner): DiffResult<Prisoner> = getDiffResult(this, other)
 }
 
 @Document(indexName = "prisoner-search-a")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.apache.commons.lang3.builder.DiffResult
+import org.apache.commons.lang3.builder.Diffable
 import org.springframework.data.annotation.Id
 import org.springframework.data.elasticsearch.annotations.DateFormat
 import org.springframework.data.elasticsearch.annotations.Document
@@ -8,9 +10,12 @@ import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.data.elasticsearch.annotations.InnerField
 import org.springframework.data.elasticsearch.annotations.MultiField
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffType
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffableType
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.getDiff
 import java.time.LocalDate
 
-open class Prisoner {
+open class Prisoner : Diffable<Prisoner> {
   @Id
   @Field(type = FieldType.Keyword)
   @Schema(required = true, description = "Prisoner Number", example = "A1234AA")
@@ -18,6 +23,7 @@ open class Prisoner {
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "PNC Number", example = "12/394773H")
+  @DiffableType(DiffType.IDENTIFIERS)
   var pncNumber: String? = null
 
   @Field(type = FieldType.Keyword)
@@ -30,14 +36,17 @@ open class Prisoner {
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "CRO Number", example = "29906/12J")
+  @DiffableType(DiffType.IDENTIFIERS)
   var croNumber: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Booking No.", example = "0001200924")
+  @DiffableType(DiffType.IDENTIFIERS)
   var bookingId: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Book Number", example = "38412A")
+  @DiffableType(DiffType.IDENTIFIERS)
   var bookNumber: String? = null
 
   @MultiField(
@@ -47,9 +56,11 @@ open class Prisoner {
     ]
   )
   @Schema(required = true, description = "First Name", example = "Robert")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var firstName: String? = null
 
   @Schema(description = "Middle Names", example = "John James")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var middleNames: String? = null
 
   @MultiField(
@@ -59,65 +70,84 @@ open class Prisoner {
     ]
   )
   @Schema(required = true, description = "Last name", example = "Larsen")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var lastName: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(required = true, description = "Date of Birth", example = "1975-04-02")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var dateOfBirth: LocalDate? = null
 
   @Schema(required = true, description = "Gender", example = "Female")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var gender: String? = null
 
   @Schema(required = true, description = "Ethnicity", example = "White: Eng./Welsh/Scot./N.Irish/British")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var ethnicity: String? = null
 
   @Schema(required = true, description = "Youth Offender?", example = "true")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var youthOffender: Boolean? = null
 
   @Schema(required = true, description = "Marital Status", example = "Widowed")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var maritalStatus: String? = null
 
   @Schema(required = true, description = "Religion", example = "Church of England (Anglican)")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var religion: String? = null
 
   @Schema(required = true, description = "Nationality", example = "Egyptian")
+  @DiffableType(DiffType.PERSONAL_DETAILS)
   var nationality: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(required = true, description = "Status of the prisoner", example = "ACTIVE IN")
+  @DiffableType(DiffType.STATUS)
   var status: String? = null
 
   @Schema(description = "Last Movement Type Code of prisoner", example = "CRT")
+  @DiffableType(DiffType.STATUS)
   var lastMovementTypeCode: String? = null
 
   @Schema(description = "Last Movement Reason of prisoner", example = "CA")
+  @DiffableType(DiffType.STATUS)
   var lastMovementReasonCode: String? = null
 
   @Schema(description = "In/Out Status", example = "IN", allowableValues = ["IN", "OUT"])
+  @DiffableType(DiffType.STATUS)
   var inOutStatus: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Prison ID", example = "MDI")
+  @DiffableType(DiffType.LOCATION)
   var prisonId: String? = null
 
   @Schema(description = "Prison Name", example = "HMP Leeds")
+  @DiffableType(DiffType.LOCATION)
   var prisonName: String? = null
 
   @Schema(description = "In prison cell location", example = "A-1-002")
+  @DiffableType(DiffType.LOCATION)
   var cellLocation: String? = null
 
   @Field(type = FieldType.Nested, includeInParent = true)
   @Schema(description = "Aliases Names and Details")
+  @DiffableType(DiffType.LOCATION)
   var aliases: List<PrisonerAlias>? = null
 
   @Field(type = FieldType.Nested, includeInParent = true)
   @Schema(description = "Alerts")
+  @DiffableType(DiffType.STATUS)
   var alerts: List<PrisonerAlert>? = null
 
   @Schema(description = "Cell Sharing Risk Assessment", example = "HIGH")
+  @DiffableType(DiffType.STATUS)
   var csra: String? = null
 
   @Schema(description = "Prisoner Category", example = "C")
+  @DiffableType(DiffType.STATUS)
   var category: String? = null
 
   @Schema(
@@ -125,64 +155,81 @@ open class Prisoner {
     example = "SENTENCED",
     allowableValues = ["RECALL", "DEAD", "INDETERMINATE_SENTENCE", "SENTENCED", "CONVICTED_UNSENTENCED", "CIVIL_PRISONER", "IMMIGRATION_DETAINEE", "REMAND", "UNKNOWN", "OTHER"]
   )
+  @DiffableType(DiffType.STATUS)
   var legalStatus: String? = null
 
   @Schema(description = "The prisoner's imprisonment status code.", example = "LIFE")
+  @DiffableType(DiffType.STATUS)
   var imprisonmentStatus: String? = null
 
   @Schema(description = "The prisoner's imprisonment status description.", example = "Serving Life Imprisonment")
+  @DiffableType(DiffType.STATUS)
   var imprisonmentStatusDescription: String? = null
 
   @Schema(required = true, description = "Most serious offence for this sentence", example = "Robbery")
+  @DiffableType(DiffType.STATUS)
   var mostSeriousOffence: String? = null
 
   @Schema(description = "Indicates that the offender has been recalled", example = "false")
+  @DiffableType(DiffType.STATUS)
   var recall: Boolean? = null
 
   @Schema(description = "Indicates the the offender has an indeterminate sentence", example = "true")
+  @DiffableType(DiffType.SENTENCE)
   var indeterminateSentence: Boolean? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Start Date for this sentence", example = "2020-04-03")
+  @DiffableType(DiffType.SENTENCE)
   var sentenceStartDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Actual of most likely Release Date", example = "2023-05-02")
+  @DiffableType(DiffType.SENTENCE)
   var releaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Release Date Confirmed", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var confirmedReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Sentence Expiry Date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var sentenceExpiryDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Licence Expiry Date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var licenceExpiryDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC Eligibility Date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var homeDetentionCurfewEligibilityDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC Actual Date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var homeDetentionCurfewActualDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC End Date", example = "2023-05-02")
+  @DiffableType(DiffType.SENTENCE)
   var homeDetentionCurfewEndDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Top-up supervision start date", example = "2023-04-29")
+  @DiffableType(DiffType.SENTENCE)
   var topupSupervisionStartDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Top-up supervision expiry date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var topupSupervisionExpiryDate: LocalDate? = null
 
   @Schema(description = "Days added to sentence term due to adjustments.", example = "10")
+  @DiffableType(DiffType.SENTENCE)
   var additionalDaysAwarded: Int? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
@@ -190,6 +237,7 @@ open class Prisoner {
     description = "Release date for Non determinant sentence (if applicable). This will be based on one of ARD, CRD, NPD or PRRD.",
     example = "2023-05-01"
   )
+  @DiffableType(DiffType.SENTENCE)
   var nonDtoReleaseDate: LocalDate? = null
 
   @Schema(
@@ -197,60 +245,76 @@ open class Prisoner {
     example = "ARD",
     allowableValues = ["ARD", "CRD", "NPD", "PRRD"]
   )
+  @DiffableType(DiffType.SENTENCE)
   var nonDtoReleaseDateType: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date prisoner was received into the prison", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var receptionDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Parole  Eligibility Date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var paroleEligibilityDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Automatic Release Date. If automaticReleaseOverrideDate is available then it will be set as automaticReleaseDate", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var automaticReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Post Recall Release Date. if postRecallReleaseOverrideDate is available then it will be set as postRecallReleaseDate", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var postRecallReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Conditional Release Date. If conditionalReleaseOverrideDate is available then it will be set as conditionalReleaseDate", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var conditionalReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Actual Parole Date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var actualParoleDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Tariff Date", example = "2023-05-01")
+  @DiffableType(DiffType.SENTENCE)
   var tariffDate: LocalDate? = null
 
   @Schema(
     description = "current prison or outside with last movement information.",
     example = "Outside - released from Leeds"
   )
+  @DiffableType(DiffType.LOCATION)
   var locationDescription: String? = null
 
   @Schema(required = true, description = "Indicates a restricted patient", example = "true")
+  @DiffableType(DiffType.RESTRICTED_PATIENT)
   var restrictedPatient: Boolean = false
 
   @Schema(description = "Supporting prison ID for POM", example = "LEI")
+  @DiffableType(DiffType.RESTRICTED_PATIENT)
   var supportingPrisonId: String? = null
 
   @Schema(description = "Which hospital the offender has been discharged to", example = "HAZLWD")
+  @DiffableType(DiffType.RESTRICTED_PATIENT)
   var dischargedHospitalId: String? = null
 
   @Schema(description = "Hospital name to which the offender was discharged", example = "Hazelwood House")
+  @DiffableType(DiffType.RESTRICTED_PATIENT)
   var dischargedHospitalDescription: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date of discharge", example = "2020-05-01")
+  @DiffableType(DiffType.RESTRICTED_PATIENT)
   var dischargeDate: LocalDate? = null
 
   @Schema(description = "Any additional discharge details", example = "Psychiatric Hospital Discharge to Hazelwood House")
   var dischargeDetails: String? = null
+
+  override fun diff(other: Prisoner): DiffResult<Prisoner> = getDiff(this, other)
 }
 
 @Document(indexName = "prisoner-search-a")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
@@ -22,7 +22,7 @@ fun getDifferencesByType(prisoner: Prisoner, other: Prisoner): Map<DiffType, Lis
     propertiesByDiffType.mapValues { properties ->
       val diffs = diffResult.diffs as List<Diff<Prisoner>>
       diffs.filter { diff -> properties.value.contains(diff.fieldName) }
-        .map { diff -> Difference(diff.fieldName, properties.key, diff.left, diff.right)}
+        .map { diff -> Difference(diff.fieldName, properties.key, diff.left, diff.right) }
     }
   }.filter { it.value.isNotEmpty() }
 
@@ -31,7 +31,7 @@ internal fun getDiff(prisoner: Prisoner, other: Prisoner): DiffResult<Prisoner> 
     Prisoner::class.members
       .filter { it.findAnnotations<DiffableType>().isNotEmpty() }
       .forEach {
-        append(it.name, it.call(prisoner), it.call(other) )
+        append(it.name, it.call(prisoner), it.call(other))
       }
   }.build()
 
@@ -39,7 +39,7 @@ val propertiesByDiffType: Map<DiffType, List<String>> =
   Prisoner::class.members
     .filter { it.findAnnotations<DiffableType>().isNotEmpty() }
     .groupBy { it.findAnnotations<DiffableType>().first().type }
-    .mapValues { it.value.map { property -> property.name} }
+    .mapValues { it.value.map { property -> property.name } }
 
 val diffTypesByProperty: Map<String, DiffType> =
   Prisoner::class.members

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.prisonersearch.services.diff
+
+import org.apache.commons.lang3.builder.Diff
+import org.apache.commons.lang3.builder.DiffBuilder
+import org.apache.commons.lang3.builder.DiffResult
+import org.apache.commons.lang3.builder.ToStringStyle
+import uk.gov.justice.digital.hmpps.prisonersearch.model.Prisoner
+import kotlin.reflect.full.findAnnotations
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DiffableType(val type: DiffType)
+
+enum class DiffType {
+  IDENTIFIERS, PERSONAL_DETAILS, STATUS, LOCATION, SENTENCE, RESTRICTED_PATIENT
+}
+
+data class Difference(val property: String, val diffType: DiffType, val oldValue: Any, val newValue: Any)
+
+fun getDifferencesByType(prisoner: Prisoner, other: Prisoner): Map<DiffType, List<Difference>> =
+  getDiff(prisoner, other).let { diffResult ->
+    propertiesByDiffType.mapValues { properties ->
+      val diffs = diffResult.diffs as List<Diff<Prisoner>>
+      diffs.filter { diff -> properties.value.contains(diff.fieldName) }
+        .map { diff -> Difference(diff.fieldName, properties.key, diff.left, diff.right)}
+    }
+  }.filter { it.value.isNotEmpty() }
+
+internal fun getDiff(prisoner: Prisoner, other: Prisoner): DiffResult<Prisoner> =
+  DiffBuilder(prisoner, other, ToStringStyle.JSON_STYLE).apply {
+    Prisoner::class.members
+      .filter { it.findAnnotations<DiffableType>().isNotEmpty() }
+      .forEach {
+        append(it.name, it.call(prisoner), it.call(other) )
+      }
+  }.build()
+
+val propertiesByDiffType: Map<DiffType, List<String>> =
+  Prisoner::class.members
+    .filter { it.findAnnotations<DiffableType>().isNotEmpty() }
+    .groupBy { it.findAnnotations<DiffableType>().first().type }
+    .mapValues { it.value.map { property -> property.name} }
+
+val diffTypesByProperty: Map<String, DiffType> =
+  Prisoner::class.members
+    .filter { it.findAnnotations<DiffableType>().isNotEmpty() }
+    .associate { it.name to it.findAnnotations<DiffableType>().first().type }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
@@ -24,24 +24,22 @@ fun getDifferencesByPropertyType(prisoner: Prisoner, other: Prisoner): Map<Prope
       diffs.filter { diff -> properties.value.contains(diff.fieldName) }
         .map { diff -> Difference(diff.fieldName, properties.key, diff.left, diff.right) }
     }
-  }.filter { it.value.isNotEmpty() }
+  }.filter { differencesByPropertyType -> differencesByPropertyType.value.isNotEmpty() }
 
 internal fun getDiffResult(prisoner: Prisoner, other: Prisoner): DiffResult<Prisoner> =
   DiffBuilder(prisoner, other, ToStringStyle.JSON_STYLE).apply {
     Prisoner::class.members
-      .filter { it.findAnnotations<DiffableProperty>().isNotEmpty() }
-      .forEach {
-        append(it.name, it.call(prisoner), it.call(other))
-      }
+      .filter { property -> property.findAnnotations<DiffableProperty>().isNotEmpty() }
+      .forEach { property -> append(property.name, property.call(prisoner), property.call(other)) }
   }.build()
 
 val propertiesByPropertyType: Map<PropertyType, List<String>> =
   Prisoner::class.members
-    .filter { it.findAnnotations<DiffableProperty>().isNotEmpty() }
-    .groupBy { it.findAnnotations<DiffableProperty>().first().type }
-    .mapValues { it.value.map { property -> property.name } }
+    .filter { property -> property.findAnnotations<DiffableProperty>().isNotEmpty() }
+    .groupBy { property -> property.findAnnotations<DiffableProperty>().first().type }
+    .mapValues { propertiesByPropertyType -> propertiesByPropertyType.value.map { property -> property.name } }
 
 val propertyTypesByProperty: Map<String, PropertyType> =
   Prisoner::class.members
-    .filter { it.findAnnotations<DiffableProperty>().isNotEmpty() }
-    .associate { it.name to it.findAnnotations<DiffableProperty>().first().type }
+    .filter { property -> property.findAnnotations<DiffableProperty>().isNotEmpty() }
+    .associate { property -> property.name to property.findAnnotations<DiffableProperty>().first().type }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -89,9 +89,9 @@ class PrisonerDiffServiceTest {
       assertThat(diffsByType.keys).containsExactly(DiffType.IDENTIFIERS)
       val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
       assertThat(identifierDiffs)
-        .extracting("property", "oldValue", "newValue")
+        .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", "somePnc1", "somePnc2"),
+          Tuple("pncNumber", DiffType.IDENTIFIERS, "somePnc1", "somePnc2"),
         )
     }
 
@@ -105,10 +105,10 @@ class PrisonerDiffServiceTest {
       assertThat(diffsByType.keys).containsExactly(DiffType.IDENTIFIERS)
       val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
       assertThat(identifierDiffs)
-        .extracting("property", "oldValue", "newValue")
+        .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", "somePnc1", "somePnc2"),
-          Tuple("croNumber", "someCro1", "someCro2"),
+          Tuple("pncNumber", DiffType.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("croNumber", DiffType.IDENTIFIERS, "someCro1", "someCro2"),
         )
     }
 
@@ -119,19 +119,20 @@ class PrisonerDiffServiceTest {
 
       val diffsByType = getDifferencesByType(prisoner1, prisoner2)
 
+      assertThat(diffsByType.keys).containsExactlyInAnyOrder(DiffType.IDENTIFIERS, DiffType.PERSONAL_DETAILS)
       val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
       val personalDetailDiffs = diffsByType[DiffType.PERSONAL_DETAILS]
 
       assertThat(identifierDiffs)
-        .extracting("property", "oldValue", "newValue")
+        .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", "somePnc1", "somePnc2"),
-          Tuple("croNumber", "someCro1", "someCro2")
+          Tuple("pncNumber", DiffType.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("croNumber", DiffType.IDENTIFIERS, "someCro1", "someCro2")
         )
       assertThat(personalDetailDiffs)
-        .extracting("property", "oldValue", "newValue")
+        .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("firstName", "someName1", "someName2"),
+          Tuple("firstName", DiffType.PERSONAL_DETAILS, "someName1", "someName2"),
         )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -17,7 +17,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "any" }
       val prisoner2 = Prisoner().apply { pncNumber = "any" }
 
-      assertThat(getDiff(prisoner1, prisoner2)).isEmpty()
+      assertThat(getDiffResult(prisoner1, prisoner2)).isEmpty()
     }
 
     @Test
@@ -25,7 +25,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2" }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs)
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs)
         .extracting("fieldName", "left", "right")
         .containsExactly(Tuple("pncNumber", "somePnc1", "somePnc2"))
     }
@@ -35,7 +35,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2" }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs)
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs)
         .extracting("fieldName", "left", "right")
         .containsExactlyInAnyOrder(
           Tuple("pncNumber", "somePnc1", "somePnc2"),
@@ -44,11 +44,11 @@ class PrisonerDiffServiceTest {
     }
 
     @Test
-    fun `should report differences of different types`() {
+    fun `should report differences of different property types`() {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; firstName = "firstName1" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; firstName = "firstName2" }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs)
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs)
         .extracting("fieldName", "left", "right")
         .containsExactlyInAnyOrder(
           Tuple("pncNumber", "somePnc1", "somePnc2"),
@@ -61,7 +61,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { youthOffender = true }
       val prisoner2 = Prisoner().apply { youthOffender = false }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs)
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs)
         .extracting("fieldName", "left", "right")
         .containsExactly(Tuple("youthOffender", true, false))
     }
@@ -71,7 +71,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = null }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc" }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs)
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs)
         .extracting("fieldName", "left", "right")
         .containsExactly(Tuple("pncNumber", null, "somePnc"))
     }
@@ -81,7 +81,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = null }
       val prisoner2 = Prisoner().apply { pncNumber = null }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs).isEmpty()
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs).isEmpty()
     }
 
     @Test
@@ -89,7 +89,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { aliases = listOf() }
       val prisoner2 = Prisoner().apply { aliases = listOf(alias(firstName = "aliasFirstName", lastName = "aliasLastName", dateOfBirth = LocalDate.now())) }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs)
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs)
         .extracting("fieldName", "left", "right")
         .containsExactly(Tuple("aliases", listOf<PrisonerAlias>(), listOf(alias(firstName = "aliasFirstName", lastName = "aliasLastName", dateOfBirth = LocalDate.now()))))
     }
@@ -102,7 +102,7 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { sentenceStartDate = LocalDate.of(2022, 9, 12) }
       val prisoner2 = Prisoner().apply { sentenceStartDate = LocalDate.of(2021, 8, 11) }
 
-      assertThat(getDiff(prisoner1, prisoner2).diffs)
+      assertThat(getDiffResult(prisoner1, prisoner2).diffs)
         .extracting("fieldName", "left", "right")
         .containsExactly(Tuple("sentenceStartDate", LocalDate.of(2022, 9, 12), LocalDate.of(2021, 8, 11)))
     }
@@ -111,26 +111,26 @@ class PrisonerDiffServiceTest {
   @Nested
   inner class Groupings {
     @Test
-    fun `groups prisoner class members by DiffType`() {
-      assertThat(propertiesByDiffType[DiffType.IDENTIFIERS]).contains("pncNumber", "croNumber")
-      assertThat(propertiesByDiffType[DiffType.PERSONAL_DETAILS]).contains("firstName")
+    fun `groups properties by property type`() {
+      assertThat(propertiesByPropertyType[PropertyType.IDENTIFIERS]).contains("pncNumber", "croNumber")
+      assertThat(propertiesByPropertyType[PropertyType.PERSONAL_DETAILS]).contains("firstName")
     }
     @Test
-    fun `calculates diff types by property name`() {
-      assertThat(diffTypesByProperty["pncNumber"]).isEqualTo(DiffType.IDENTIFIERS)
-      assertThat(diffTypesByProperty["croNumber"]).isEqualTo(DiffType.IDENTIFIERS)
-      assertThat(diffTypesByProperty["firstName"]).isEqualTo(DiffType.PERSONAL_DETAILS)
+    fun `maps property types by property`() {
+      assertThat(propertyTypesByProperty["pncNumber"]).isEqualTo(PropertyType.IDENTIFIERS)
+      assertThat(propertyTypesByProperty["croNumber"]).isEqualTo(PropertyType.IDENTIFIERS)
+      assertThat(propertyTypesByProperty["firstName"]).isEqualTo(PropertyType.PERSONAL_DETAILS)
     }
   }
 
   @Nested
-  inner class GroupDiffsByType {
+  inner class GetDifferencesByPropertyType {
     @Test
     fun `should report zero differences`() {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc"; croNumber = "someCro"; firstName = "someName" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc"; croNumber = "someCro"; firstName = "someName" }
 
-      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
 
       assertThat(diffsByType).isEmpty()
     }
@@ -140,14 +140,14 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro"; firstName = "someName" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro"; firstName = "someName" }
 
-      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactly(DiffType.IDENTIFIERS)
-      val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
+      assertThat(diffsByType.keys).containsExactly(PropertyType.IDENTIFIERS)
+      val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
       assertThat(identifierDiffs)
         .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", DiffType.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
         )
     }
 
@@ -156,39 +156,39 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1"; firstName = "someName" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2"; firstName = "someName" }
 
-      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactly(DiffType.IDENTIFIERS)
-      val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
+      assertThat(diffsByType.keys).containsExactly(PropertyType.IDENTIFIERS)
+      val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
       assertThat(identifierDiffs)
         .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", DiffType.IDENTIFIERS, "somePnc1", "somePnc2"),
-          Tuple("croNumber", DiffType.IDENTIFIERS, "someCro1", "someCro2"),
+          Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("croNumber", PropertyType.IDENTIFIERS, "someCro1", "someCro2"),
         )
     }
 
     @Test
-    fun `should report multiple differences of multiple types`() {
+    fun `should report multiple differences of multiple property types`() {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1"; firstName = "someName1" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2"; firstName = "someName2" }
 
-      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactlyInAnyOrder(DiffType.IDENTIFIERS, DiffType.PERSONAL_DETAILS)
-      val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
-      val personalDetailDiffs = diffsByType[DiffType.PERSONAL_DETAILS]
+      assertThat(diffsByType.keys).containsExactlyInAnyOrder(PropertyType.IDENTIFIERS, PropertyType.PERSONAL_DETAILS)
+      val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
+      val personalDetailDiffs = diffsByType[PropertyType.PERSONAL_DETAILS]
 
       assertThat(identifierDiffs)
         .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", DiffType.IDENTIFIERS, "somePnc1", "somePnc2"),
-          Tuple("croNumber", DiffType.IDENTIFIERS, "someCro1", "someCro2")
+          Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("croNumber", PropertyType.IDENTIFIERS, "someCro1", "someCro2")
         )
       assertThat(personalDetailDiffs)
         .extracting("property", "diffType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("firstName", DiffType.PERSONAL_DETAILS, "someName1", "someName2"),
+          Tuple("firstName", PropertyType.PERSONAL_DETAILS, "someName1", "someName2"),
         )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -62,7 +62,7 @@ class PrisonerDiffServiceTest {
       assertThat(propertiesByDiffType[DiffType.IDENTIFIERS]).contains("pncNumber", "croNumber")
       assertThat(propertiesByDiffType[DiffType.PERSONAL_DETAILS]).contains("firstName")
     }
-        @Test
+    @Test
     fun `calculates diff types by property name`() {
       assertThat(diffTypesByProperty["pncNumber"]).isEqualTo(DiffType.IDENTIFIERS)
       assertThat(diffTypesByProperty["croNumber"]).isEqualTo(DiffType.IDENTIFIERS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -145,7 +145,7 @@ class PrisonerDiffServiceTest {
       assertThat(diffsByType.keys).containsExactly(PropertyType.IDENTIFIERS)
       val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
       assertThat(identifierDiffs)
-        .extracting("property", "diffType", "oldValue", "newValue")
+        .extracting("property", "propertyType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
           Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
         )
@@ -161,7 +161,7 @@ class PrisonerDiffServiceTest {
       assertThat(diffsByType.keys).containsExactly(PropertyType.IDENTIFIERS)
       val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
       assertThat(identifierDiffs)
-        .extracting("property", "diffType", "oldValue", "newValue")
+        .extracting("property", "propertyType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
           Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
           Tuple("croNumber", PropertyType.IDENTIFIERS, "someCro1", "someCro2"),
@@ -180,13 +180,13 @@ class PrisonerDiffServiceTest {
       val personalDetailDiffs = diffsByType[PropertyType.PERSONAL_DETAILS]
 
       assertThat(identifierDiffs)
-        .extracting("property", "diffType", "oldValue", "newValue")
+        .extracting("property", "propertyType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
           Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
           Tuple("croNumber", PropertyType.IDENTIFIERS, "someCro1", "someCro2")
         )
       assertThat(personalDetailDiffs)
-        .extracting("property", "diffType", "oldValue", "newValue")
+        .extracting("property", "propertyType", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
           Tuple("firstName", PropertyType.PERSONAL_DETAILS, "someName1", "someName2"),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -1,0 +1,138 @@
+package uk.gov.justice.digital.hmpps.prisonersearch.services.diff
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.prisonersearch.model.Prisoner
+
+class PrisonerDiffServiceTest {
+
+  @Nested
+  inner class CreateDiff {
+    @Test
+    fun `should find no differences`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "any" }
+      val prisoner2 = Prisoner().apply { pncNumber = "any" }
+
+      assertThat(getDiff(prisoner1, prisoner2)).isEmpty()
+    }
+
+    @Test
+    fun `should report single difference`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "somePnc1" }
+      val prisoner2 = Prisoner().apply { pncNumber = "somePnc2" }
+
+      assertThat(getDiff(prisoner1, prisoner2).diffs)
+        .extracting("fieldName", "left", "right")
+        .containsExactly(Tuple("pncNumber", "somePnc1", "somePnc2"))
+    }
+
+    @Test
+    fun `should report multiple differences`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1" }
+      val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2" }
+
+      assertThat(getDiff(prisoner1, prisoner2).diffs)
+        .extracting("fieldName", "left", "right")
+        .containsExactlyInAnyOrder(
+          Tuple("pncNumber", "somePnc1", "somePnc2"),
+          Tuple("croNumber", "someCro1", "someCro2")
+        )
+    }
+
+    @Test
+    fun `should report differences of different types`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; firstName = "firstName1" }
+      val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; firstName = "firstName2" }
+
+      assertThat(getDiff(prisoner1, prisoner2).diffs)
+        .extracting("fieldName", "left", "right")
+        .containsExactlyInAnyOrder(
+          Tuple("pncNumber", "somePnc1", "somePnc2"),
+          Tuple("firstName", "firstName1", "firstName2")
+        )
+    }
+  }
+
+  @Nested
+  inner class GroupDiffsByType {
+    @Test
+    fun `groups prisoner class members by DiffType`() {
+      assertThat(propertiesByDiffType[DiffType.IDENTIFIERS]).contains("pncNumber", "croNumber")
+      assertThat(propertiesByDiffType[DiffType.PERSONAL_DETAILS]).contains("firstName")
+    }
+        @Test
+    fun `calculates diff types by property name`() {
+      assertThat(diffTypesByProperty["pncNumber"]).isEqualTo(DiffType.IDENTIFIERS)
+      assertThat(diffTypesByProperty["croNumber"]).isEqualTo(DiffType.IDENTIFIERS)
+      assertThat(diffTypesByProperty["firstName"]).isEqualTo(DiffType.PERSONAL_DETAILS)
+    }
+
+    @Test
+    fun `should report zero differences`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "somePnc"; croNumber = "someCro"; firstName = "someName" }
+      val prisoner2 = Prisoner().apply { pncNumber = "somePnc"; croNumber = "someCro"; firstName = "someName" }
+
+      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+
+      assertThat(diffsByType).isEmpty()
+    }
+
+    @Test
+    fun `should report single difference`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro"; firstName = "someName" }
+      val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro"; firstName = "someName" }
+
+      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+
+      assertThat(diffsByType.keys).containsExactly(DiffType.IDENTIFIERS)
+      val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
+      assertThat(identifierDiffs)
+        .extracting("property", "oldValue", "newValue")
+        .containsExactlyInAnyOrder(
+          Tuple("pncNumber", "somePnc1", "somePnc2"),
+        )
+    }
+
+    @Test
+    fun `should report multiple differences`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1"; firstName = "someName" }
+      val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2"; firstName = "someName" }
+
+      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+
+      assertThat(diffsByType.keys).containsExactly(DiffType.IDENTIFIERS)
+      val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
+      assertThat(identifierDiffs)
+        .extracting("property", "oldValue", "newValue")
+        .containsExactlyInAnyOrder(
+          Tuple("pncNumber", "somePnc1", "somePnc2"),
+          Tuple("croNumber", "someCro1", "someCro2"),
+        )
+    }
+
+    @Test
+    fun `should report multiple differences of multiple types`() {
+      val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1"; firstName = "someName1" }
+      val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2"; firstName = "someName2" }
+
+      val diffsByType = getDifferencesByType(prisoner1, prisoner2)
+
+      val identifierDiffs = diffsByType[DiffType.IDENTIFIERS]
+      val personalDetailDiffs = diffsByType[DiffType.PERSONAL_DETAILS]
+
+      assertThat(identifierDiffs)
+        .extracting("property", "oldValue", "newValue")
+        .containsExactlyInAnyOrder(
+          Tuple("pncNumber", "somePnc1", "somePnc2"),
+          Tuple("croNumber", "someCro1", "someCro2")
+        )
+      assertThat(personalDetailDiffs)
+        .extracting("property", "oldValue", "newValue")
+        .containsExactlyInAnyOrder(
+          Tuple("firstName", "someName1", "someName2"),
+        )
+    }
+  }
+}


### PR DESCRIPTION
The long term goal is to publish Domain events when a prisoner is updated. By categorising the properties of the Prisoner we can say which kind of properties have changed so consumers can react to changes they are interested in.