### PR TITLE
SDI-287 add telemetry for prisoner differences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
@@ -98,10 +98,12 @@ class PrisonerIndexService(
     }
 
     existingPrisoner?.also {
-      getDifferencesByPropertyType(it, storedPrisoner)
-        .also { differences ->
-          raiseDifferencesTelemetry(offenderBooking.offenderNo, offenderBooking.bookingNo, differences, telemetryClient)
-        }
+      raiseDifferencesTelemetry(
+        offenderBooking.offenderNo,
+        offenderBooking.bookingNo,
+        getDifferencesByPropertyType(it, storedPrisoner),
+        telemetryClient
+      )
     }
 
     return storedPrisoner

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/RestrictedPatientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/RestrictedPatientService.kt
@@ -9,6 +9,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.RestrictedPatientDto
 
+@Service
 interface RestrictedPatientService {
   fun getRestrictedPatient(prisonerNumber: String): RestrictedPatientDto?
 }


### PR DESCRIPTION
A customEvent with name `POSPrisonerUpdated` is raised listing the properties that have changed in customDimensions.

It should now be possible to query App Insights for recent changes to prisoners in prisoner-offender-search with a query like:
```
customEvents
| where cloud_RoleName == 'prisoner-offender-search'
| where name == 'POSPrisonerUpdated'
| extend offender=tostring(customDimensions.offenderNo)
| where offender == 'A1234AA'
```
Or to find out when a specific property changed, something like:
```
customEvents
| where cloud_RoleName == 'prisoner-offender-search'
| where name == 'POSPrisonerUpdated'
| extend offender=tostring(customDimensions.offenderNo)
| where offender == 'A1234AA'
| where isnotempty(customDimensions.inOutStatus)
```