### PR TITLE
SDI-287 Cater for null differences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
@@ -16,7 +16,7 @@ enum class PropertyType {
   IDENTIFIERS, PERSONAL_DETAILS, STATUS, LOCATION, SENTENCE, RESTRICTED_PATIENT
 }
 
-data class Difference(val property: String, val propertyType: PropertyType, val oldValue: Any, val newValue: Any)
+data class Difference(val property: String, val propertyType: PropertyType, val oldValue: Any?, val newValue: Any?)
 
 fun getDifferencesByPropertyType(prisoner: Prisoner, other: Prisoner): Map<PropertyType, List<Difference>> =
   getDiffResult(prisoner, other).let { diffResult ->


### PR DESCRIPTION
Receive / release of an offender clears many fields in the Elasticsearch Prisoner entity - allow these null fields in Prisoner differences