### PR TITLE
SDI-287 refactor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/Prisoner.kt
@@ -10,8 +10,8 @@ import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.data.elasticsearch.annotations.InnerField
 import org.springframework.data.elasticsearch.annotations.MultiField
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffCategory
 import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffableProperty
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PropertyType
 import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.getDiffResult
 import java.time.LocalDate
 
@@ -23,7 +23,7 @@ open class Prisoner : Diffable<Prisoner> {
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "PNC Number", example = "12/394773H")
-  @DiffableProperty(PropertyType.IDENTIFIERS)
+  @DiffableProperty(DiffCategory.IDENTIFIERS)
   var pncNumber: String? = null
 
   @Field(type = FieldType.Keyword)
@@ -36,17 +36,17 @@ open class Prisoner : Diffable<Prisoner> {
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "CRO Number", example = "29906/12J")
-  @DiffableProperty(PropertyType.IDENTIFIERS)
+  @DiffableProperty(DiffCategory.IDENTIFIERS)
   var croNumber: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Booking No.", example = "0001200924")
-  @DiffableProperty(PropertyType.IDENTIFIERS)
+  @DiffableProperty(DiffCategory.IDENTIFIERS)
   var bookingId: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Book Number", example = "38412A")
-  @DiffableProperty(PropertyType.IDENTIFIERS)
+  @DiffableProperty(DiffCategory.IDENTIFIERS)
   var bookNumber: String? = null
 
   @MultiField(
@@ -56,11 +56,11 @@ open class Prisoner : Diffable<Prisoner> {
     ]
   )
   @Schema(required = true, description = "First Name", example = "Robert")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var firstName: String? = null
 
   @Schema(description = "Middle Names", example = "John James")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var middleNames: String? = null
 
   @MultiField(
@@ -70,84 +70,84 @@ open class Prisoner : Diffable<Prisoner> {
     ]
   )
   @Schema(required = true, description = "Last name", example = "Larsen")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var lastName: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(required = true, description = "Date of Birth", example = "1975-04-02")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var dateOfBirth: LocalDate? = null
 
   @Schema(required = true, description = "Gender", example = "Female")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var gender: String? = null
 
   @Schema(required = true, description = "Ethnicity", example = "White: Eng./Welsh/Scot./N.Irish/British")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var ethnicity: String? = null
 
   @Schema(required = true, description = "Youth Offender?", example = "true")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var youthOffender: Boolean? = null
 
   @Schema(required = true, description = "Marital Status", example = "Widowed")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var maritalStatus: String? = null
 
   @Schema(required = true, description = "Religion", example = "Church of England (Anglican)")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var religion: String? = null
 
   @Schema(required = true, description = "Nationality", example = "Egyptian")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var nationality: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(required = true, description = "Status of the prisoner", example = "ACTIVE IN")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var status: String? = null
 
   @Schema(description = "Last Movement Type Code of prisoner", example = "CRT")
-  @DiffableProperty(PropertyType.LOCATION)
+  @DiffableProperty(DiffCategory.LOCATION)
   var lastMovementTypeCode: String? = null
 
   @Schema(description = "Last Movement Reason of prisoner", example = "CA")
-  @DiffableProperty(PropertyType.LOCATION)
+  @DiffableProperty(DiffCategory.LOCATION)
   var lastMovementReasonCode: String? = null
 
   @Schema(description = "In/Out Status", example = "IN", allowableValues = ["IN", "OUT"])
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var inOutStatus: String? = null
 
   @Field(type = FieldType.Keyword)
   @Schema(description = "Prison ID", example = "MDI")
-  @DiffableProperty(PropertyType.LOCATION)
+  @DiffableProperty(DiffCategory.LOCATION)
   var prisonId: String? = null
 
   @Schema(description = "Prison Name", example = "HMP Leeds")
-  @DiffableProperty(PropertyType.LOCATION)
+  @DiffableProperty(DiffCategory.LOCATION)
   var prisonName: String? = null
 
   @Schema(description = "In prison cell location", example = "A-1-002")
-  @DiffableProperty(PropertyType.LOCATION)
+  @DiffableProperty(DiffCategory.LOCATION)
   var cellLocation: String? = null
 
   @Field(type = FieldType.Nested, includeInParent = true)
   @Schema(description = "Aliases Names and Details")
-  @DiffableProperty(PropertyType.PERSONAL_DETAILS)
+  @DiffableProperty(DiffCategory.PERSONAL_DETAILS)
   var aliases: List<PrisonerAlias>? = null
 
   @Field(type = FieldType.Nested, includeInParent = true)
   @Schema(description = "Alerts")
-  @DiffableProperty(PropertyType.ALERTS)
+  @DiffableProperty(DiffCategory.ALERTS)
   var alerts: List<PrisonerAlert>? = null
 
   @Schema(description = "Cell Sharing Risk Assessment", example = "HIGH")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var csra: String? = null
 
   @Schema(description = "Prisoner Category", example = "C")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var category: String? = null
 
   @Schema(
@@ -155,81 +155,81 @@ open class Prisoner : Diffable<Prisoner> {
     example = "SENTENCED",
     allowableValues = ["RECALL", "DEAD", "INDETERMINATE_SENTENCE", "SENTENCED", "CONVICTED_UNSENTENCED", "CIVIL_PRISONER", "IMMIGRATION_DETAINEE", "REMAND", "UNKNOWN", "OTHER"]
   )
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var legalStatus: String? = null
 
   @Schema(description = "The prisoner's imprisonment status code.", example = "LIFE")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var imprisonmentStatus: String? = null
 
   @Schema(description = "The prisoner's imprisonment status description.", example = "Serving Life Imprisonment")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var imprisonmentStatusDescription: String? = null
 
   @Schema(required = true, description = "Most serious offence for this sentence", example = "Robbery")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var mostSeriousOffence: String? = null
 
   @Schema(description = "Indicates that the offender has been recalled", example = "false")
-  @DiffableProperty(PropertyType.STATUS)
+  @DiffableProperty(DiffCategory.STATUS)
   var recall: Boolean? = null
 
   @Schema(description = "Indicates the the offender has an indeterminate sentence", example = "true")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var indeterminateSentence: Boolean? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Start Date for this sentence", example = "2020-04-03")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var sentenceStartDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Actual of most likely Release Date", example = "2023-05-02")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var releaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Release Date Confirmed", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var confirmedReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Sentence Expiry Date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var sentenceExpiryDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Licence Expiry Date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var licenceExpiryDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC Eligibility Date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var homeDetentionCurfewEligibilityDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC Actual Date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var homeDetentionCurfewActualDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "HDC End Date", example = "2023-05-02")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var homeDetentionCurfewEndDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Top-up supervision start date", example = "2023-04-29")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var topupSupervisionStartDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Top-up supervision expiry date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var topupSupervisionExpiryDate: LocalDate? = null
 
   @Schema(description = "Days added to sentence term due to adjustments.", example = "10")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var additionalDaysAwarded: Int? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
@@ -237,7 +237,7 @@ open class Prisoner : Diffable<Prisoner> {
     description = "Release date for Non determinant sentence (if applicable). This will be based on one of ARD, CRD, NPD or PRRD.",
     example = "2023-05-01"
   )
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var nonDtoReleaseDate: LocalDate? = null
 
   @Schema(
@@ -245,70 +245,70 @@ open class Prisoner : Diffable<Prisoner> {
     example = "ARD",
     allowableValues = ["ARD", "CRD", "NPD", "PRRD"]
   )
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var nonDtoReleaseDateType: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date prisoner was received into the prison", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var receptionDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Parole  Eligibility Date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var paroleEligibilityDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Automatic Release Date. If automaticReleaseOverrideDate is available then it will be set as automaticReleaseDate", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var automaticReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Post Recall Release Date. if postRecallReleaseOverrideDate is available then it will be set as postRecallReleaseDate", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var postRecallReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Conditional Release Date. If conditionalReleaseOverrideDate is available then it will be set as conditionalReleaseDate", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var conditionalReleaseDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Actual Parole Date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var actualParoleDate: LocalDate? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Tariff Date", example = "2023-05-01")
-  @DiffableProperty(PropertyType.SENTENCE)
+  @DiffableProperty(DiffCategory.SENTENCE)
   var tariffDate: LocalDate? = null
 
   @Schema(
     description = "current prison or outside with last movement information.",
     example = "Outside - released from Leeds"
   )
-  @DiffableProperty(PropertyType.LOCATION)
+  @DiffableProperty(DiffCategory.LOCATION)
   var locationDescription: String? = null
 
   @Schema(required = true, description = "Indicates a restricted patient", example = "true")
-  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
+  @DiffableProperty(DiffCategory.RESTRICTED_PATIENT)
   var restrictedPatient: Boolean = false
 
   @Schema(description = "Supporting prison ID for POM", example = "LEI")
-  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
+  @DiffableProperty(DiffCategory.RESTRICTED_PATIENT)
   var supportingPrisonId: String? = null
 
   @Schema(description = "Which hospital the offender has been discharged to", example = "HAZLWD")
-  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
+  @DiffableProperty(DiffCategory.RESTRICTED_PATIENT)
   var dischargedHospitalId: String? = null
 
   @Schema(description = "Hospital name to which the offender was discharged", example = "Hazelwood House")
-  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
+  @DiffableProperty(DiffCategory.RESTRICTED_PATIENT)
   var dischargedHospitalDescription: String? = null
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date of discharge", example = "2020-05-01")
-  @DiffableProperty(PropertyType.RESTRICTED_PATIENT)
+  @DiffableProperty(DiffCategory.RESTRICTED_PATIENT)
   var dischargeDate: LocalDate? = null
 
   @Schema(description = "Any additional discharge details", example = "Psychiatric Hospital Discharge to Hazelwood House")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import uk.gov.justice.digital.hmpps.prisonersearch.config.DiffProperties
 import uk.gov.justice.digital.hmpps.prisonersearch.services.HmppsDomainEventEmitter.Companion.EVENT_TYPE
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffCategory
 import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PrisonerDifferences
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PropertyType
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import java.time.Clock
 import java.time.Instant
@@ -63,7 +63,7 @@ class HmppsDomainEventEmitter(
 data class PrisonerUpdatedEvent(
   val offenderNo: String,
   val bookingNo: String?,
-  val propertyTypes: List<PropertyType>,
+  val categoriesChanged: List<DiffCategory>,
 )
 
 data class PrisonerUpdatedDomainEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
@@ -56,7 +56,7 @@ class HmppsDomainEventEmitter(
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
-    const val EVENT_TYPE = "prisoner-offender-search.offender.updated"
+    const val EVENT_TYPE = "prisoner-offender-search.prisoner.updated"
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
@@ -33,11 +33,10 @@ class HmppsDomainEventEmitter(
 
   fun emitPrisonerDifferenceEvent(
     offenderNo: String,
-    bookingNo: String?,
     differences: PrisonerDifferences,
   ) {
     runCatching {
-      PrisonerUpdatedEvent(offenderNo, bookingNo, differences.keys.toList().sorted())
+      PrisonerUpdatedEvent(offenderNo, differences.keys.toList().sorted())
         .let { event -> PrisonerUpdatedDomainEvent(event, Instant.now(clock), diffProperties.host) }
         .let { domainEvent ->
           PublishRequest(topicArn, objectMapper.writeValueAsString(domainEvent))
@@ -48,7 +47,7 @@ class HmppsDomainEventEmitter(
     }
       .onFailure {
         log.error(
-          "Failed to send prisoner updated event for offenderNo=$offenderNo, bookingNo=$bookingNo, differences=$differences",
+          "Failed to send prisoner updated event for offenderNo=$offenderNo, differences=$differences",
           it
         )
       }
@@ -61,8 +60,7 @@ class HmppsDomainEventEmitter(
 }
 
 data class PrisonerUpdatedEvent(
-  val offenderNo: String,
-  val bookingNo: String?,
+  val nomsNumber: String,
   val categoriesChanged: List<DiffCategory>,
 )
 
@@ -81,6 +79,6 @@ data class PrisonerUpdatedDomainEvent(
       eventType = EVENT_TYPE,
       version = 1,
       description = "A prisoner record has been updated",
-      detailUrl = ServletUriComponentsBuilder.fromUriString(host).path("/prisoner/{offenderNo}").buildAndExpand(additionalInfo.offenderNo).toUri().toString(),
+      detailUrl = ServletUriComponentsBuilder.fromUriString(host).path("/prisoner/{offenderNo}").buildAndExpand(additionalInfo.nomsNumber).toUri().toString(),
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.model.SyncIndex
 import uk.gov.justice.digital.hmpps.prisonersearch.model.translate
 import uk.gov.justice.digital.hmpps.prisonersearch.repository.PrisonerARepository
 import uk.gov.justice.digital.hmpps.prisonersearch.repository.PrisonerBRepository
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.getDifferencesByPropertyType
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.getDifferencesByCategory
 import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.raiseDifferencesTelemetry
 import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.OffenderBooking
 import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.RestrictivePatient
@@ -118,7 +118,7 @@ class PrisonerIndexService(
         raiseDifferencesTelemetry(
           offenderBooking.offenderNo,
           offenderBooking.bookingNo,
-          getDifferencesByPropertyType(it, storedPrisoner),
+          getDifferencesByCategory(it, storedPrisoner),
           telemetryClient
         )
       }.onFailure {
@@ -136,7 +136,7 @@ class PrisonerIndexService(
 
     existingPrisoner?.also { prisoner ->
       kotlin.runCatching {
-        getDifferencesByPropertyType(prisoner, storedPrisoner)
+        getDifferencesByCategory(prisoner, storedPrisoner)
           .takeIf { differences -> differences.isNotEmpty() }
           ?.also { differences ->
             domainEventEmitter.emitPrisonerDifferenceEvent(offenderBooking.offenderNo, offenderBooking.bookingNo, differences)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
@@ -117,7 +117,6 @@ class PrisonerIndexService(
       kotlin.runCatching {
         raiseDifferencesTelemetry(
           offenderBooking.offenderNo,
-          offenderBooking.bookingNo,
           getDifferencesByCategory(it, storedPrisoner),
           telemetryClient
         )
@@ -139,7 +138,7 @@ class PrisonerIndexService(
         getDifferencesByCategory(prisoner, storedPrisoner)
           .takeIf { differences -> differences.isNotEmpty() }
           ?.also { differences ->
-            domainEventEmitter.emitPrisonerDifferenceEvent(offenderBooking.offenderNo, offenderBooking.bookingNo, differences)
+            domainEventEmitter.emitPrisonerDifferenceEvent(offenderBooking.offenderNo, differences)
           }
       }.onFailure {
         log.error("prisoner-offender-search.offender.updated event failed with error", it)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
@@ -17,7 +17,7 @@ enum class DiffCategory {
   IDENTIFIERS, PERSONAL_DETAILS, ALERTS, STATUS, LOCATION, SENTENCE, RESTRICTED_PATIENT
 }
 
-data class Difference(val property: String, val diffCategory: DiffCategory, val oldValue: Any?, val newValue: Any?)
+data class Difference(val property: String, val categoryChanged: DiffCategory, val oldValue: Any?, val newValue: Any?)
 
 typealias PrisonerDifferences = Map<DiffCategory, List<Difference>>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
@@ -58,7 +58,7 @@ fun raiseDifferencesTelemetry(
       "POSPrisonerUpdated",
       mapOf(
         "processedTime" to LocalDateTime.now().toString(),
-        "offenderNumber" to offenderNo,
+        "nomsNumber" to offenderNo,
         "categoryChanged" to diffCategoryMap.key.name,
       ) + diffCategoryMap.value.associate { difference ->
         difference.property to """${difference.oldValue} -> ${difference.newValue}"""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDifferenceService.kt
@@ -50,7 +50,6 @@ val diffCategoriesByProperty: Map<String, DiffCategory> =
 
 fun raiseDifferencesTelemetry(
   offenderNo: String,
-  bookingNo: String?,
   differences: PrisonerDifferences,
   telemetryClient: TelemetryClient
 ) {
@@ -60,7 +59,6 @@ fun raiseDifferencesTelemetry(
       mapOf(
         "processedTime" to LocalDateTime.now().toString(),
         "offenderNumber" to offenderNo,
-        "bookingNumber" to bookingNo,
         "categoryChanged" to diffCategoryMap.key.name,
       ) + diffCategoryMap.value.associate { difference ->
         difference.property to """${difference.oldValue} -> ${difference.newValue}"""

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
@@ -41,7 +41,7 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
       val result = hmppsEventsQueue.sqsClient.receiveMessage(hmppsEventsQueue.queueUrl).messages.first()
       val message: MsgBody = objectMapper.readValue(result.body)
 
-      assertThatJson(message.Message).node("eventType").isEqualTo("prisoner-offender-search.offender.updated")
+      assertThatJson(message.Message).node("eventType").isEqualTo("prisoner-offender-search.prisoner.updated")
       assertThatJson(message.Message).node("version").isEqualTo(1)
       assertThatJson(message.Message).node("occurredAt").isEqualTo("2022-09-16T11:40:34+01:00")
       assertThatJson(message.Message).node("detailUrl").isEqualTo("http://localhost:8080/prisoner/some_offender")
@@ -89,7 +89,7 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
       // The update should have triggered a prisoner updated domain event
       val result = hmppsEventsQueue.sqsClient.receiveMessage(hmppsEventsQueue.queueUrl).messages.first()
       val msgBody: MsgBody = objectMapper.readValue(result.body)
-      assertThatJson(msgBody.Message).node("eventType").isEqualTo("prisoner-offender-search.offender.updated")
+      assertThatJson(msgBody.Message).node("eventType").isEqualTo("prisoner-offender-search.prisoner.updated")
       assertThatJson(msgBody.Message).node("additionalInfo.offenderNo").isEqualTo("A1239DD")
       assertThatJson(msgBody.Message).node("additionalInfo.propertyTypes").isArray.containsExactlyInAnyOrder("PERSONAL_DETAILS")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
@@ -34,7 +34,7 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
   inner class EmitPrisonerDifferenceEvent {
     @Test
     fun `sends prisoner differences to the domain topic`() {
-      hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", "some_booking", mapOf(IDENTIFIERS to listOf(), LOCATION to listOf()))
+      hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", mapOf(IDENTIFIERS to listOf(), LOCATION to listOf()))
 
       await untilCallTo { getNumberOfMessagesCurrentlyOnDomainQueue() } matches { it == 1 }
 
@@ -46,7 +46,6 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
       assertThatJson(message.Message).node("occurredAt").isEqualTo("2022-09-16T11:40:34+01:00")
       assertThatJson(message.Message).node("detailUrl").isEqualTo("http://localhost:8080/prisoner/some_offender")
       assertThatJson(message.Message).node("additionalInfo.offenderNo").isEqualTo("some_offender")
-      assertThatJson(message.Message).node("additionalInfo.bookingNo").isEqualTo("some_booking")
       assertThatJson(message.Message).node("additionalInfo.categoriesChanged").isArray.containsExactlyInAnyOrder("IDENTIFIERS", "LOCATION")
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
@@ -45,7 +45,7 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
       assertThatJson(message.Message).node("version").isEqualTo(1)
       assertThatJson(message.Message).node("occurredAt").isEqualTo("2022-09-16T11:40:34+01:00")
       assertThatJson(message.Message).node("detailUrl").isEqualTo("http://localhost:8080/prisoner/some_offender")
-      assertThatJson(message.Message).node("additionalInfo.offenderNo").isEqualTo("some_offender")
+      assertThatJson(message.Message).node("additionalInfo.nomsNumber").isEqualTo("some_offender")
       assertThatJson(message.Message).node("additionalInfo.categoriesChanged").isArray.containsExactlyInAnyOrder("IDENTIFIERS", "LOCATION")
     }
 
@@ -89,7 +89,7 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
       val result = hmppsEventsQueue.sqsClient.receiveMessage(hmppsEventsQueue.queueUrl).messages.first()
       val msgBody: MsgBody = objectMapper.readValue(result.body)
       assertThatJson(msgBody.Message).node("eventType").isEqualTo("prisoner-offender-search.prisoner.updated")
-      assertThatJson(msgBody.Message).node("additionalInfo.offenderNo").isEqualTo("A1239DD")
+      assertThatJson(msgBody.Message).node("additionalInfo.nomsNumber").isEqualTo("A1239DD")
       assertThatJson(msgBody.Message).node("additionalInfo.categoriesChanged").isArray.containsExactlyInAnyOrder("PERSONAL_DETAILS")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
@@ -17,8 +17,8 @@ import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.prisonersearch.PrisonerBuilder
 import uk.gov.justice.digital.hmpps.prisonersearch.QueueIntegrationTest
 import uk.gov.justice.digital.hmpps.prisonersearch.readResourceAsText
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PropertyType.IDENTIFIERS
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PropertyType.LOCATION
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffCategory.IDENTIFIERS
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffCategory.LOCATION
 import uk.gov.justice.hmpps.sqs.PurgeQueueRequest
 
 class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
@@ -47,7 +47,7 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
       assertThatJson(message.Message).node("detailUrl").isEqualTo("http://localhost:8080/prisoner/some_offender")
       assertThatJson(message.Message).node("additionalInfo.offenderNo").isEqualTo("some_offender")
       assertThatJson(message.Message).node("additionalInfo.bookingNo").isEqualTo("some_booking")
-      assertThatJson(message.Message).node("additionalInfo.propertyTypes").isArray.containsExactlyInAnyOrder("IDENTIFIERS", "LOCATION")
+      assertThatJson(message.Message).node("additionalInfo.categoriesChanged").isArray.containsExactlyInAnyOrder("IDENTIFIERS", "LOCATION")
     }
 
     @Test
@@ -91,7 +91,7 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
       val msgBody: MsgBody = objectMapper.readValue(result.body)
       assertThatJson(msgBody.Message).node("eventType").isEqualTo("prisoner-offender-search.prisoner.updated")
       assertThatJson(msgBody.Message).node("additionalInfo.offenderNo").isEqualTo("A1239DD")
-      assertThatJson(msgBody.Message).node("additionalInfo.propertyTypes").isArray.containsExactlyInAnyOrder("PERSONAL_DETAILS")
+      assertThatJson(msgBody.Message).node("additionalInfo.categoriesChanged").isArray.containsExactlyInAnyOrder("PERSONAL_DETAILS")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
@@ -49,7 +49,7 @@ class HmppsDomainEventsEmitterTest {
 
     verify(topicSnsClient).publish(
       check {
-        assertThat(it.messageAttributes["eventType"]?.stringValue).isEqualTo("prisoner-offender-search.offender.updated")
+        assertThat(it.messageAttributes["eventType"]?.stringValue).isEqualTo("prisoner-offender-search.prisoner.updated")
       }
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
@@ -45,7 +45,7 @@ class HmppsDomainEventsEmitterTest {
 
   @Test
   fun `should include event type as a message attribute`() {
-    hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", "some_booking", mapOf(DiffCategory.LOCATION to listOf()))
+    hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", mapOf(DiffCategory.LOCATION to listOf()))
 
     verify(topicSnsClient).publish(
       check {
@@ -59,7 +59,7 @@ class HmppsDomainEventsEmitterTest {
     whenever(topicSnsClient.publish(any())).thenThrow(RuntimeException::class.java)
 
     assertDoesNotThrow {
-      hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", "some_booking", mapOf(DiffCategory.LOCATION to listOf()))
+      hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", mapOf(DiffCategory.LOCATION to listOf()))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
@@ -13,7 +13,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.prisonersearch.config.DiffProperties
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PropertyType
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffCategory
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
 import java.time.Clock
@@ -45,7 +45,7 @@ class HmppsDomainEventsEmitterTest {
 
   @Test
   fun `should include event type as a message attribute`() {
-    hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", "some_booking", mapOf(PropertyType.LOCATION to listOf()))
+    hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", "some_booking", mapOf(DiffCategory.LOCATION to listOf()))
 
     verify(topicSnsClient).publish(
       check {
@@ -59,7 +59,7 @@ class HmppsDomainEventsEmitterTest {
     whenever(topicSnsClient.publish(any())).thenThrow(RuntimeException::class.java)
 
     assertDoesNotThrow {
-      hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", "some_booking", mapOf(PropertyType.LOCATION to listOf()))
+      hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", "some_booking", mapOf(DiffCategory.LOCATION to listOf()))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexServiceTest.kt
@@ -300,7 +300,7 @@ class PrisonerIndexServiceTest {
 
       prisonerIndexService.sync(someOffenderBooking())
 
-      verify(domainEventsEmitter).emitPrisonerDifferenceEvent(eq("someOffenderNo"), isNull(), anyMap())
+      verify(domainEventsEmitter).emitPrisonerDifferenceEvent(eq("someOffenderNo"), anyMap())
     }
 
     @Test
@@ -309,7 +309,7 @@ class PrisonerIndexServiceTest {
 
       prisonerIndexService.sync(someOffenderBooking())
 
-      verify(domainEventsEmitter, never()).emitPrisonerDifferenceEvent(eq("someOffenderNo"), isNull(), anyMap())
+      verify(domainEventsEmitter, never()).emitPrisonerDifferenceEvent(eq("someOffenderNo"), anyMap())
     }
 
     @Test
@@ -318,13 +318,13 @@ class PrisonerIndexServiceTest {
 
       prisonerIndexService.sync(someOffenderBooking())
 
-      verify(domainEventsEmitter, never()).emitPrisonerDifferenceEvent(eq("someOffenderNo"), isNull(), anyMap())
+      verify(domainEventsEmitter, never()).emitPrisonerDifferenceEvent(eq("someOffenderNo"), anyMap())
     }
 
     @Test
     fun `should handle exceptions when sending events`() {
       whenever(prisonerARepository.findById(anyString())).thenReturn(Optional.of(PrisonerA().apply { pncNumber = "somePncNumber1" }))
-      whenever(domainEventsEmitter.emitPrisonerDifferenceEvent(anyString(), anyString(), anyMap())).thenThrow(RuntimeException::class.java)
+      whenever(domainEventsEmitter.emitPrisonerDifferenceEvent(anyString(), anyMap())).thenThrow(RuntimeException::class.java)
 
       val saved = prisonerIndexService.sync(someOffenderBooking())
 
@@ -338,7 +338,7 @@ class PrisonerIndexServiceTest {
 
       prisonerIndexService.sync(someOffenderBooking())
 
-      verify(domainEventsEmitter, never()).emitPrisonerDifferenceEvent(eq("someOffenderNo"), isNull(), anyMap())
+      verify(domainEventsEmitter, never()).emitPrisonerDifferenceEvent(eq("someOffenderNo"), anyMap())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -250,7 +250,6 @@ class PrisonerDiffServiceTest {
 
       raiseDifferencesTelemetry(
         "someOffenderNo",
-        "someBookingNo",
         getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
@@ -260,7 +259,6 @@ class PrisonerDiffServiceTest {
         check<Map<String, String>> {
           assertThat(LocalDateTime.parse(it["processedTime"]).toLocalDate()).isEqualTo(LocalDate.now())
           assertThat(it["offenderNumber"]).isEqualTo("someOffenderNo")
-          assertThat(it["bookingNumber"]).isEqualTo("someBookingNo")
         },
         isNull()
       )
@@ -273,7 +271,6 @@ class PrisonerDiffServiceTest {
 
       raiseDifferencesTelemetry(
         "someOffenderNo",
-        "someBookingNo",
         getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
@@ -295,7 +292,6 @@ class PrisonerDiffServiceTest {
 
       raiseDifferencesTelemetry(
         "someOffenderNo",
-        "someBookingNo",
         getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
@@ -318,7 +314,6 @@ class PrisonerDiffServiceTest {
 
       raiseDifferencesTelemetry(
         "someOffenderNo",
-        "someBookingNo",
         getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
@@ -341,7 +336,6 @@ class PrisonerDiffServiceTest {
 
       raiseDifferencesTelemetry(
         "someOffenderNo",
-        "someBookingNo",
         getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -258,7 +258,7 @@ class PrisonerDiffServiceTest {
         eq("POSPrisonerUpdated"),
         check<Map<String, String>> {
           assertThat(LocalDateTime.parse(it["processedTime"]).toLocalDate()).isEqualTo(LocalDate.now())
-          assertThat(it["offenderNumber"]).isEqualTo("someOffenderNo")
+          assertThat(it["nomsNumber"]).isEqualTo("someOffenderNo")
         },
         isNull()
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -120,26 +120,26 @@ class PrisonerDiffServiceTest {
   inner class Groupings {
     @Test
     fun `groups properties by property type`() {
-      assertThat(propertiesByPropertyType[PropertyType.IDENTIFIERS]).contains("pncNumber", "croNumber")
-      assertThat(propertiesByPropertyType[PropertyType.PERSONAL_DETAILS]).contains("firstName")
+      assertThat(propertiesByDiffCategory[DiffCategory.IDENTIFIERS]).contains("pncNumber", "croNumber")
+      assertThat(propertiesByDiffCategory[DiffCategory.PERSONAL_DETAILS]).contains("firstName")
     }
 
     @Test
     fun `maps property types by property`() {
-      assertThat(propertyTypesByProperty["pncNumber"]).isEqualTo(PropertyType.IDENTIFIERS)
-      assertThat(propertyTypesByProperty["croNumber"]).isEqualTo(PropertyType.IDENTIFIERS)
-      assertThat(propertyTypesByProperty["firstName"]).isEqualTo(PropertyType.PERSONAL_DETAILS)
+      assertThat(diffCategoriesByProperty["pncNumber"]).isEqualTo(DiffCategory.IDENTIFIERS)
+      assertThat(diffCategoriesByProperty["croNumber"]).isEqualTo(DiffCategory.IDENTIFIERS)
+      assertThat(diffCategoriesByProperty["firstName"]).isEqualTo(DiffCategory.PERSONAL_DETAILS)
     }
   }
 
   @Nested
-  inner class GetDifferencesByPropertyType {
+  inner class GetDifferencesByCategory {
     @Test
     fun `should report zero differences`() {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc"; croNumber = "someCro"; firstName = "someName" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc"; croNumber = "someCro"; firstName = "someName" }
 
-      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByCategory(prisoner1, prisoner2)
 
       assertThat(diffsByType).isEmpty()
     }
@@ -149,14 +149,14 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro"; firstName = "someName" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro"; firstName = "someName" }
 
-      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByCategory(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactly(PropertyType.IDENTIFIERS)
-      val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
+      assertThat(diffsByType.keys).containsExactly(DiffCategory.IDENTIFIERS)
+      val identifierDiffs = diffsByType[DiffCategory.IDENTIFIERS]
       assertThat(identifierDiffs)
-        .extracting("property", "propertyType", "oldValue", "newValue")
+        .extracting("property", "categoryChanged", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("pncNumber", DiffCategory.IDENTIFIERS, "somePnc1", "somePnc2"),
         )
     }
 
@@ -165,15 +165,15 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc"; croNumber = null; firstName = "someName" }
       val prisoner2 = Prisoner().apply { pncNumber = null; croNumber = "someCro"; firstName = "someName" }
 
-      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByCategory(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactly(PropertyType.IDENTIFIERS)
-      val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
+      assertThat(diffsByType.keys).containsExactly(DiffCategory.IDENTIFIERS)
+      val identifierDiffs = diffsByType[DiffCategory.IDENTIFIERS]
       assertThat(identifierDiffs)
-        .extracting("property", "propertyType", "oldValue", "newValue")
+        .extracting("property", "categoryChanged", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc", null),
-          Tuple("croNumber", PropertyType.IDENTIFIERS, null, "someCro"),
+          Tuple("pncNumber", DiffCategory.IDENTIFIERS, "somePnc", null),
+          Tuple("croNumber", DiffCategory.IDENTIFIERS, null, "someCro"),
         )
     }
 
@@ -182,15 +182,15 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1"; firstName = "someName" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2"; firstName = "someName" }
 
-      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByCategory(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactly(PropertyType.IDENTIFIERS)
-      val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
+      assertThat(diffsByType.keys).containsExactly(DiffCategory.IDENTIFIERS)
+      val identifierDiffs = diffsByType[DiffCategory.IDENTIFIERS]
       assertThat(identifierDiffs)
-        .extracting("property", "propertyType", "oldValue", "newValue")
+        .extracting("property", "categoryChanged", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
-          Tuple("croNumber", PropertyType.IDENTIFIERS, "someCro1", "someCro2"),
+          Tuple("pncNumber", DiffCategory.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("croNumber", DiffCategory.IDENTIFIERS, "someCro1", "someCro2"),
         )
     }
 
@@ -199,22 +199,22 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1"; croNumber = "someCro1"; firstName = "someName1" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2"; croNumber = "someCro2"; firstName = "someName2" }
 
-      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByCategory(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactlyInAnyOrder(PropertyType.IDENTIFIERS, PropertyType.PERSONAL_DETAILS)
-      val identifierDiffs = diffsByType[PropertyType.IDENTIFIERS]
-      val personalDetailDiffs = diffsByType[PropertyType.PERSONAL_DETAILS]
+      assertThat(diffsByType.keys).containsExactlyInAnyOrder(DiffCategory.IDENTIFIERS, DiffCategory.PERSONAL_DETAILS)
+      val identifierDiffs = diffsByType[DiffCategory.IDENTIFIERS]
+      val personalDetailDiffs = diffsByType[DiffCategory.PERSONAL_DETAILS]
 
       assertThat(identifierDiffs)
-        .extracting("property", "propertyType", "oldValue", "newValue")
+        .extracting("property", "categoryChanged", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("pncNumber", PropertyType.IDENTIFIERS, "somePnc1", "somePnc2"),
-          Tuple("croNumber", PropertyType.IDENTIFIERS, "someCro1", "someCro2")
+          Tuple("pncNumber", DiffCategory.IDENTIFIERS, "somePnc1", "somePnc2"),
+          Tuple("croNumber", DiffCategory.IDENTIFIERS, "someCro1", "someCro2")
         )
       assertThat(personalDetailDiffs)
-        .extracting("property", "propertyType", "oldValue", "newValue")
+        .extracting("property", "categoryChanged", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          Tuple("firstName", PropertyType.PERSONAL_DETAILS, "someName1", "someName2"),
+          Tuple("firstName", DiffCategory.PERSONAL_DETAILS, "someName1", "someName2"),
         )
     }
 
@@ -223,15 +223,15 @@ class PrisonerDiffServiceTest {
       val prisoner1 = Prisoner().apply { alerts = listOf(alert()) }
       val prisoner2 = Prisoner().apply { alerts = listOf(alert(active = false)) }
 
-      val diffsByType = getDifferencesByPropertyType(prisoner1, prisoner2)
+      val diffsByType = getDifferencesByCategory(prisoner1, prisoner2)
 
-      assertThat(diffsByType.keys).containsExactlyInAnyOrder(PropertyType.ALERTS)
-      val alertsDiffs = diffsByType[PropertyType.ALERTS]
+      assertThat(diffsByType.keys).containsExactlyInAnyOrder(DiffCategory.ALERTS)
+      val alertsDiffs = diffsByType[DiffCategory.ALERTS]
 
       assertThat(alertsDiffs)
-        .extracting("property", "propertyType", "oldValue", "newValue")
+        .extracting("property", "categoryChanged", "oldValue", "newValue")
         .containsExactlyInAnyOrder(
-          (Tuple("alerts", PropertyType.ALERTS, listOf(alert()), listOf(alert(active = false))))
+          (Tuple("alerts", DiffCategory.ALERTS, listOf(alert()), listOf(alert(active = false))))
         )
     }
 
@@ -251,7 +251,7 @@ class PrisonerDiffServiceTest {
       raiseDifferencesTelemetry(
         "someOffenderNo",
         "someBookingNo",
-        getDifferencesByPropertyType(prisoner1, prisoner2),
+        getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
 
@@ -274,14 +274,14 @@ class PrisonerDiffServiceTest {
       raiseDifferencesTelemetry(
         "someOffenderNo",
         "someBookingNo",
-        getDifferencesByPropertyType(prisoner1, prisoner2),
+        getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
 
       verify(telemetryClient).trackEvent(
         eq("POSPrisonerUpdated"),
         check<Map<String, String>> {
-          assertThat(it["propertyTypes"]).isEqualTo(PropertyType.IDENTIFIERS.name)
+          assertThat(it["categoryChanged"]).isEqualTo(DiffCategory.IDENTIFIERS.name)
           assertThat(it["pncNumber"]).isEqualTo("somePnc1 -> somePnc2")
         },
         isNull()
@@ -296,14 +296,14 @@ class PrisonerDiffServiceTest {
       raiseDifferencesTelemetry(
         "someOffenderNo",
         "someBookingNo",
-        getDifferencesByPropertyType(prisoner1, prisoner2),
+        getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
 
       verify(telemetryClient).trackEvent(
         eq("POSPrisonerUpdated"),
         check<Map<String, String>> {
-          assertThat(it["propertyTypes"]).isEqualTo(PropertyType.IDENTIFIERS.name)
+          assertThat(it["categoryChanged"]).isEqualTo(DiffCategory.IDENTIFIERS.name)
           assertThat(it["pncNumber"]).isEqualTo("somePnc1 -> somePnc2")
           assertThat(it["croNumber"]).isEqualTo("someCro1 -> someCro2")
         },
@@ -319,14 +319,14 @@ class PrisonerDiffServiceTest {
       raiseDifferencesTelemetry(
         "someOffenderNo",
         "someBookingNo",
-        getDifferencesByPropertyType(prisoner1, prisoner2),
+        getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
 
       verify(telemetryClient).trackEvent(
         eq("POSPrisonerUpdated"),
         check<Map<String, String>> {
-          assertThat(it["propertyTypes"]).isEqualTo(PropertyType.IDENTIFIERS.name)
+          assertThat(it["categoryChanged"]).isEqualTo(DiffCategory.IDENTIFIERS.name)
           assertThat(it["pncNumber"]).isEqualTo("somePnc -> null")
           assertThat(it["croNumber"]).isEqualTo("null -> someCro")
         },
@@ -342,7 +342,7 @@ class PrisonerDiffServiceTest {
       raiseDifferencesTelemetry(
         "someOffenderNo",
         "someBookingNo",
-        getDifferencesByPropertyType(prisoner1, prisoner2),
+        getDifferencesByCategory(prisoner1, prisoner2),
         telemetryClient
       )
 
@@ -350,7 +350,7 @@ class PrisonerDiffServiceTest {
         .trackEvent(
           eq("POSPrisonerUpdated"),
           check<Map<String, String>> {
-            assertThat(it["propertyTypes"]).isEqualTo(PropertyType.IDENTIFIERS.name)
+            assertThat(it["categoryChanged"]).isEqualTo(DiffCategory.IDENTIFIERS.name)
             assertThat(it["pncNumber"]).isEqualTo("somePnc1 -> somePnc2")
             assertThat(it["croNumber"]).isEqualTo("someCro1 -> someCro2")
           },
@@ -361,7 +361,7 @@ class PrisonerDiffServiceTest {
         .trackEvent(
           eq("POSPrisonerUpdated"),
           check<Map<String, String>> {
-            assertThat(it["propertyTypes"]).isEqualTo(PropertyType.PERSONAL_DETAILS.name)
+            assertThat(it["categoryChanged"]).isEqualTo(DiffCategory.PERSONAL_DETAILS.name)
             assertThat(it["firstName"]).isEqualTo("someFirstName1 -> someFirstName2")
           },
           isNull()


### PR DESCRIPTION
* Prisoner updated event changed from `offender.updated` to `prisoner.updated` to align with prison-offender-events naming strategy 
* And `offenderNo` changed to `nomsNumber` to align with POE
* `PropertyType` (used to group changed properties) renamed to `DiffCategory` in the code and `categoriesChanged` in the events
* booking number removed as noms number is the key identifier (booking may or may not exist)