### PR TITLE
SDI-287 prevent duplicate events and allow retries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
@@ -47,10 +47,8 @@ class HmppsDomainEventEmitter(
         }
     }
       .onFailure {
-        log.error(
-          "Failed to send prisoner updated event for offenderNo=$offenderNo, differences=$differences",
-          it
-        )
+        log.error("Failed to send event $UPDATED_EVENT_TYPE for offenderNo=$offenderNo, differences=$differences")
+        throw it
       }
   }
 
@@ -66,7 +64,8 @@ class HmppsDomainEventEmitter(
         }
     }
       .onFailure {
-        log.error("Failed to send prisoner created event for offenderNo=$offenderNo", it)
+        log.error("Failed to send event $CREATED_EVENT_TYPE for offenderNo=$offenderNo", it)
+        throw it
       }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterTest.kt
@@ -3,10 +3,10 @@ package uk.gov.justice.digital.hmpps.prisonersearch.services
 import com.amazonaws.services.sns.AmazonSNS
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
@@ -58,12 +58,12 @@ class HmppsDomainEventsEmitterTest {
     }
 
     @Test
-    fun `should swallow exceptions`() {
+    fun `should not swallow exceptions`() {
       whenever(topicSnsClient.publish(any())).thenThrow(RuntimeException::class.java)
 
-      assertDoesNotThrow {
+      assertThatThrownBy {
         hmppsDomainEventEmitter.emitPrisonerDifferenceEvent("some_offender", mapOf(DiffCategory.LOCATION to listOf()))
-      }
+      }.isInstanceOf(RuntimeException::class.java)
     }
   }
 
@@ -81,12 +81,12 @@ class HmppsDomainEventsEmitterTest {
     }
 
     @Test
-    fun `should swallow exceptions`() {
+    fun `should not swallow exceptions`() {
       whenever(topicSnsClient.publish(any())).thenThrow(RuntimeException::class.java)
 
-      assertDoesNotThrow {
+      assertThatThrownBy {
         hmppsDomainEventEmitter.emitPrisonerCreatedEvent("some_offender")
-      }
+      }.isInstanceOf(RuntimeException::class.java)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerDiffServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.services.diff
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -502,15 +503,15 @@ class PrisonerDiffServiceTest {
     }
 
     @Test
-    fun `should swallow exceptions when raising telemetry`() {
+    fun `should NOT swallow exceptions when sending domain events`() {
       whenever(domainEventsEmitter.emitPrisonerDifferenceEvent(anyString(), any())).thenThrow(RuntimeException::class.java)
 
       val prisoner1 = Prisoner().apply { pncNumber = "somePnc1" }
       val prisoner2 = Prisoner().apply { pncNumber = "somePnc2" }
 
-      assertDoesNotThrow {
+      assertThatThrownBy {
         prisonerDifferenceService.generateDiffEvent(prisoner1, someOffenderBooking(), prisoner2)
-      }
+      }.isInstanceOf(RuntimeException::class.java)
     }
   }
 


### PR DESCRIPTION
* Check if the prisoner document on ES has actually changed before sending the prisoner updated domain event
* Stop swallowing exceptions if the domain event fails - allow the exception to percolate so the original prison event is rejected and retried
* Rollback the prisoner hash update if the domain event fails - so the retried prison event is not ignored  and the domain event is sent