### PR TITLE
SDI-287 duplicate prisoner events hash

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerEventHashRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerEventHashRepository.kt
@@ -30,7 +30,7 @@ interface PrisonerEventHashRepository : JpaRepository<PrisonerEventHash, String>
       "SET prisoner_hash=:prisonerHash, updated_date_time=:updatedDateTime WHERE prisoner_event_hashes.prisoner_hash<>:prisonerHash",
     nativeQuery = true
   )
-  fun upsertPrisonerEventHashIfChanged(nomsNumber: String, prisonerHash: Int, updatedDateTime: Instant): Int
+  fun upsertPrisonerEventHashIfChanged(nomsNumber: String, prisonerHash: String, updatedDateTime: Instant): Int
 }
 
 @Entity
@@ -39,7 +39,7 @@ data class PrisonerEventHash(
   @Id
   val nomsNumber: String = "",
   @Column(name = "prisoner_hash")
-  val prisonerHash: Int = 0,
+  val prisonerHash: String = "",
   val updatedDateTime: Instant = Instant.now(),
 ) {
   override fun equals(other: Any?): Boolean {

--- a/src/main/resources/db/migration/V1_2__prisoner_event_sent.sql
+++ b/src/main/resources/db/migration/V1_2__prisoner_event_sent.sql
@@ -1,0 +1,3 @@
+DELETE FROM prisoner_event_hashes;
+
+ALTER TABLE prisoner_event_hashes ALTER COLUMN prisoner_hash TYPE varchar(24);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/integration/IntegrationTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.services.HmppsDomainEventEmit
 import uk.gov.justice.digital.hmpps.prisonersearch.services.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonerIndexService
 import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PrisonerDifferenceService
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PrisonerEventHashRepository
 import uk.gov.justice.hmpps.sqs.HmppsQueueFactory
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
@@ -92,6 +93,9 @@ abstract class IntegrationTest {
   @SpyBean
   protected lateinit var prisonerDifferenceService: PrisonerDifferenceService
 
+  @Autowired
+  protected lateinit var prisonerEventHashRepository: PrisonerEventHashRepository
+
   companion object {
     internal val prisonMockServer = PrisonMockServer()
     internal val oauthMockServer = OAuthMockServer()
@@ -134,6 +138,12 @@ abstract class IntegrationTest {
     whenever(clock.instant()).thenReturn(fixedClock.instant())
     whenever(clock.zone).thenReturn(fixedClock.zone)
   }
+
+  @BeforeEach
+  fun clearPrisonerHashes() {
+    prisonerEventHashRepository.deleteAll()
+  }
+
   internal fun Any.asJson() = gson.toJson(this)
 
   internal fun setAuthorisation(user: String = "prisoner-search-client", roles: List<String> = listOf()): (HttpHeaders) -> Unit {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/integration/IntegrationTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.integration.wiremock.Restrict
 import uk.gov.justice.digital.hmpps.prisonersearch.services.HmppsDomainEventEmitter
 import uk.gov.justice.digital.hmpps.prisonersearch.services.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.prisonersearch.services.PrisonerIndexService
+import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PrisonerDifferenceService
 import uk.gov.justice.hmpps.sqs.HmppsQueueFactory
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
@@ -87,6 +88,9 @@ abstract class IntegrationTest {
 
   @Autowired
   protected lateinit var prisonerIndexService: PrisonerIndexService
+
+  @SpyBean
+  protected lateinit var prisonerDifferenceService: PrisonerDifferenceService
 
   companion object {
     internal val prisonMockServer = PrisonMockServer()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
@@ -17,19 +17,14 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.prisonersearch.PrisonerBuilder
 import uk.gov.justice.digital.hmpps.prisonersearch.QueueIntegrationTest
 import uk.gov.justice.digital.hmpps.prisonersearch.readResourceAsText
 import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffCategory.IDENTIFIERS
 import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.DiffCategory.LOCATION
-import uk.gov.justice.digital.hmpps.prisonersearch.services.diff.PrisonerEventHashRepository
 import uk.gov.justice.hmpps.sqs.PurgeQueueRequest
 
 class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
-
-  @Autowired
-  private lateinit var prisonerEventHashRepository: PrisonerEventHashRepository
 
   @BeforeEach
   fun purgeHmppsEventsQueue() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventsEmitterIntTest.kt
@@ -12,6 +12,7 @@ import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -116,6 +117,63 @@ class HmppsDomainEventsEmitterIntTest : QueueIntegrationTest() {
     assertThatJson(updateMsgBody.Message).node("eventType").isEqualTo("prisoner-offender-search.prisoner.updated")
     assertThatJson(updateMsgBody.Message).node("additionalInfo.nomsNumber").isEqualTo("A1239DD")
     assertThatJson(updateMsgBody.Message).node("additionalInfo.categoriesChanged").isArray.containsExactlyInAnyOrder("PERSONAL_DETAILS")
+  }
+
+  @Test
+  fun `e2e - will send single prisoner updated event for 2 identical updates`() {
+    prisonerIndexService.delete("A1239DD")
+    prisonMockServer.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/api/offenders/A1239DD"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(PrisonerBuilder(prisonerNumber = "A1239DD").toOffenderBooking())
+        )
+    )
+    val message = "/messages/offenderDetailsChanged.json".readResourceAsText().replace("A7089FD", "A1239DD")
+
+    // create the prisoner in ES
+    search(SearchCriteria("A1239DD", null, null), "/results/empty.json")
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
+    eventQueueSqsClient.sendMessage(eventQueueUrl, message)
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
+    await untilCallTo { prisonRequestCountFor("/api/offenders/A1239DD") } matches { it == 1 }
+
+    // Should receive a prisoner created domain event
+    await untilCallTo { getNumberOfMessagesCurrentlyOnDomainQueue() } matches { it == 1 }
+    val createResult = hmppsEventsQueue.sqsClient.receiveMessage(hmppsEventsQueue.queueUrl).messages.first()
+    val createMsgBody: MsgBody = objectMapper.readValue(createResult.body)
+    assertThatJson(createMsgBody.Message).node("eventType").isEqualTo("prisoner-offender-search.prisoner.created")
+    assertThatJson(createMsgBody.Message).node("additionalInfo.nomsNumber").isEqualTo("A1239DD")
+
+    // update the prisoner on ES - TWICE
+    prisonMockServer.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/api/offenders/A1239DD"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(PrisonerBuilder(prisonerNumber = "A1239DD", firstName = "NEW_NAME").toOffenderBooking())
+        )
+    )
+    eventQueueSqsClient.sendMessage(eventQueueUrl, message)
+    eventQueueSqsClient.sendMessage(eventQueueUrl, message)
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
+
+    // expecting 3 attempts at messages - the initial create then 2 updates
+    await untilCallTo { calledHandleDifferences(times = 3) } matches { it == true }
+
+    // but there is only 1 message on the domain queue because the last update was ignored
+    assertThat(getNumberOfMessagesCurrentlyOnDomainQueue()).isEqualTo(1)
+  }
+
+  fun calledHandleDifferences(times: Int): Boolean {
+    kotlin.runCatching {
+      verify(prisonerDifferenceService, times(times)).handleDifferences(anyOrNull(), any(), any())
+    }
+      .onFailure {
+        return false
+      }
+    return true
   }
 
   /*

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerEventHashRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/diff/PrisonerEventHashRepositoryTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.prisonersearch.services.diff
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.prisonersearch.integration.IntegrationTest
 import uk.gov.justice.digital.hmpps.prisonersearch.services.toNullable
@@ -11,49 +10,46 @@ import java.time.temporal.ChronoUnit
 
 class PrisonerEventHashRepositoryTest : IntegrationTest() {
 
-  @Autowired
-  private lateinit var prisonerEventHashRepository: PrisonerEventHashRepository
-
-  private fun upsert(nomsNumber: String, hash: Int, dateTime: Instant) = prisonerEventHashRepository.upsertPrisonerEventHashIfChanged(nomsNumber, hash, dateTime)
+  private fun upsert(nomsNumber: String, hash: String, dateTime: Instant) = prisonerEventHashRepository.upsertPrisonerEventHashIfChanged(nomsNumber, hash, dateTime)
   private fun find(nomsNumber: String) = prisonerEventHashRepository.findById(nomsNumber).toNullable()
   private fun now() = Instant.now().truncatedTo(ChronoUnit.MICROS) // Postgres only handles microseconds, but some System clocks can go to nanoseconds.
 
   @Test
   @Transactional
   fun `should save a new prisoner event hash`() {
-    val rowsUpdated = upsert("A1111AA", 111, now())
+    val rowsUpdated = upsert("A1111AA", "aaa", now())
     assertThat(rowsUpdated).isEqualTo(1)
 
     val saved = find("A1111AA")
-    assertThat(saved?.prisonerHash).isEqualTo(111)
+    assertThat(saved?.prisonerHash).isEqualTo("aaa")
   }
 
   @Test
   @Transactional
   fun `should save multiple new prisoner event hashes`() {
-    var rowsUpdated = upsert("A1111AA", 111, now())
+    var rowsUpdated = upsert("A1111AA", "aaa", now())
     assertThat(rowsUpdated).isEqualTo(1)
 
-    rowsUpdated = upsert("A2222AA", 222, now())
+    rowsUpdated = upsert("A2222AA", "bbb", now())
     assertThat(rowsUpdated).isEqualTo(1)
 
     val saved = find("A2222AA")
-    assertThat(saved?.prisonerHash).isEqualTo(222)
+    assertThat(saved?.prisonerHash).isEqualTo("bbb")
   }
 
   @Test
   @Transactional
   fun `should update a changed prisoner event hash`() {
     val insertTime = now().minusSeconds(1)
-    var rowsUpdated = upsert("A1111AA", 111, insertTime)
+    var rowsUpdated = upsert("A1111AA", "aaa", insertTime)
     assertThat(rowsUpdated).isEqualTo(1)
 
     val updateTime = insertTime.plusSeconds(1)
-    rowsUpdated = upsert("A1111AA", 112, updateTime)
+    rowsUpdated = upsert("A1111AA", "aab", updateTime)
     assertThat(rowsUpdated).isEqualTo(1)
 
     val saved = find("A1111AA")
-    assertThat(saved?.prisonerHash).isEqualTo(112)
+    assertThat(saved?.prisonerHash).isEqualTo("aab")
     assertThat(saved?.updatedDateTime).isEqualTo(updateTime)
   }
 
@@ -61,15 +57,15 @@ class PrisonerEventHashRepositoryTest : IntegrationTest() {
   @Transactional
   fun `should not update an unchanged prisoner event hash`() {
     val insertTime = now().minusSeconds(1)
-    var rowsUpdated = upsert("A1111AA", 111, insertTime)
+    var rowsUpdated = upsert("A1111AA", "aaa", insertTime)
     assertThat(rowsUpdated).isEqualTo(1)
 
     val updateTime = insertTime.plusSeconds(1)
-    rowsUpdated = upsert("A1111AA", 111, updateTime)
+    rowsUpdated = upsert("A1111AA", "aaa", updateTime)
     assertThat(rowsUpdated).isEqualTo(0)
 
     val saved = find("A1111AA")
-    assertThat(saved?.prisonerHash).isEqualTo(111)
+    assertThat(saved?.prisonerHash).isEqualTo("aaa")
     assertThat(saved?.updatedDateTime).isEqualTo(insertTime)
   }
 
@@ -77,26 +73,26 @@ class PrisonerEventHashRepositoryTest : IntegrationTest() {
   @Transactional
   fun `should update multiple existing prisoner event hashes`() {
     val insertTime = now().minusSeconds(1)
-    var rowsUpdated = upsert("A1111AA", 111, insertTime)
+    var rowsUpdated = upsert("A1111AA", "aaa", insertTime)
     assertThat(rowsUpdated).isEqualTo(1)
-    rowsUpdated = upsert("A2222AA", 222, insertTime)
+    rowsUpdated = upsert("A2222AA", "bbb", insertTime)
     assertThat(rowsUpdated).isEqualTo(1)
 
     val updateTime = insertTime.plusSeconds(1)
-    rowsUpdated = upsert("A1111AA", 112, updateTime)
+    rowsUpdated = upsert("A1111AA", "aab", updateTime)
     assertThat(rowsUpdated).isEqualTo(1)
-    rowsUpdated = upsert("A2222AA", 222, updateTime)
+    rowsUpdated = upsert("A2222AA", "bbb", updateTime)
     assertThat(rowsUpdated).isEqualTo(0)
     val updateTime2 = updateTime.plusSeconds(1)
-    rowsUpdated = upsert("A2222AA", 223, updateTime2)
+    rowsUpdated = upsert("A2222AA", "bbc", updateTime2)
     assertThat(rowsUpdated).isEqualTo(1)
 
     var saved = find("A1111AA")
-    assertThat(saved?.prisonerHash).isEqualTo(112)
+    assertThat(saved?.prisonerHash).isEqualTo("aab")
     assertThat(saved?.updatedDateTime).isEqualTo(updateTime)
 
     saved = find("A2222AA")
-    assertThat(saved?.prisonerHash).isEqualTo(223)
+    assertThat(saved?.prisonerHash).isEqualTo("bbc")
     assertThat(saved?.updatedDateTime).isEqualTo(updateTime2)
   }
 }


### PR DESCRIPTION
The `hashCode()` API is only guaranteed to work on the same Java process - no good for distributed computing.

Instead generate a unique hash from the JSON representation of the Prisoner document (as stored in ElasticSearch) to decide whether an updated event has already been published for the prisoner.