### PR TITLE
Reduce DB connections to allow more pods

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ spring:
     password: ${DB_PASS}
     hikari:
       pool-name: POS-DB-CP
-      maximum-pool-size: 20
+      maximum-pool-size: 10
       connection-timeout: 30000
       validation-timeout: 5000
 


### PR DESCRIPTION
We tried to increase to 12 pods to have a temporary burst on message handling but hit an AWS limit (error message "FATAL: remaining connection slots are reserved for non-replication superuser connections"). We can increase the number of available connections by increasing the DB Instance size... but this seems overkill as the DB is tiny and traffic is minimal. Therefore I've reduced the connection pool size hopefully freeing up connections to allow more pods.