### PR TITLE
SDI-452 Continue with reindex when Incentive failure

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/translator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/model/translator.kt
@@ -7,12 +7,16 @@ import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.OffenderBooking
 import uk.gov.justice.digital.hmpps.prisonersearch.services.dto.RestrictivePatient
 
 fun PrisonerA(ob: OffenderBooking, incentiveLevel: IncentiveLevel?, restrictedPatientData: RestrictivePatient?) =
-  PrisonerA().apply { this.translate(ob, incentiveLevel, restrictedPatientData) }
+  PrisonerA().apply { this.translate(null, ob, Result.success(incentiveLevel), restrictedPatientData) }
+fun PrisonerA(existingPrisoner: Prisoner?, ob: OffenderBooking, incentiveLevel: Result<IncentiveLevel?>, restrictedPatientData: RestrictivePatient?) =
+  PrisonerA().apply { this.translate(existingPrisoner, ob, incentiveLevel, restrictedPatientData) }
 
 fun PrisonerB(ob: OffenderBooking, incentiveLevel: IncentiveLevel?, restrictedPatientData: RestrictivePatient?) =
-  PrisonerB().apply { this.translate(ob, incentiveLevel, restrictedPatientData) }
+  PrisonerB().apply { this.translate(null, ob, Result.success(incentiveLevel), restrictedPatientData) }
+fun PrisonerB(existingPrisoner: Prisoner?, ob: OffenderBooking, incentiveLevel: Result<IncentiveLevel?>, restrictedPatientData: RestrictivePatient?) =
+  PrisonerB().apply { this.translate(existingPrisoner, ob, incentiveLevel, restrictedPatientData) }
 
-fun Prisoner.translate(ob: OffenderBooking, incentiveLevel: IncentiveLevel?, restrictedPatientData: RestrictivePatient?) {
+fun Prisoner.translate(existingPrisoner: Prisoner?, ob: OffenderBooking, incentiveLevel: Result<IncentiveLevel?>, restrictedPatientData: RestrictivePatient?) {
   this.prisonerNumber = ob.offenderNo
   this.bookNumber = ob.bookingNo
   this.bookingId = ob.bookingId?.toString()
@@ -96,7 +100,7 @@ fun Prisoner.translate(ob: OffenderBooking, incentiveLevel: IncentiveLevel?, res
   this.dischargeDate = restrictedPatientData?.dischargeDate
   this.dischargeDetails = restrictedPatientData?.dischargeDetails
 
-  this.currentIncentive = incentiveLevel.toCurrentIncentive()
+  this.currentIncentive = incentiveLevel.map { it.toCurrentIncentive() }.getOrElse { existingPrisoner?.currentIncentive }
 }
 
 private fun IncentiveLevel?.toCurrentIncentive(): CurrentIncentive? = this?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerIndexService.kt
@@ -48,7 +48,7 @@ class PrisonerIndexService(
 
   fun indexPrisoner(prisonerId: String) {
     nomisService.getOffender(prisonerId)?.let {
-      reIndex(offenderBooking = it)
+      index(offenderBooking = it)
     } ?: run {
       telemetryClient.trackEvent(
         "POSOffenderNotFoundForIndexing",
@@ -60,7 +60,7 @@ class PrisonerIndexService(
 
   fun syncPrisoner(prisonerId: String): Prisoner? =
     nomisService.getOffender(prisonerId)?.let {
-      sync(offenderBooking = it)
+      reindex(offenderBooking = it)
     } ?: run {
       telemetryClient.trackEvent(
         "POSOffenderNotFoundForIndexing",
@@ -87,7 +87,8 @@ class PrisonerIndexService(
     }.map { it }.orElse(null)
   }
 
-  fun sync(offenderBooking: OffenderBooking): Prisoner {
+  // called when prisoner record has changed
+  fun reindex(offenderBooking: OffenderBooking): Prisoner {
     val existingPrisoner = get(offenderBooking.offenderNo)
 
     val restrictedPatientData = offenderBooking.getRestrictedPatientData()
@@ -107,7 +108,8 @@ class PrisonerIndexService(
     return storedPrisoner
   }
 
-  fun reIndex(offenderBooking: OffenderBooking): Prisoner {
+  // called when rebuilding the index from scratch
+  fun index(offenderBooking: OffenderBooking): Prisoner {
     val restrictivePatient: RestrictivePatient? = offenderBooking.getRestrictedPatientData()
     val incentiveLevel = offenderBooking.getIncentiveLevel()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSyncService.kt
@@ -61,7 +61,7 @@ class PrisonerSyncService(
 
   private fun syncByNomsNumber(offenderIdDisplay: String) {
     nomisService.getOffender(offenderIdDisplay)?.run {
-      prisonerIndexService.sync(this)
+      prisonerIndexService.reindex(this)
     }
   }
 
@@ -83,7 +83,7 @@ class PrisonerSyncService(
         prisonerIndexService.delete(prisonerId)
       } else {
         log.debug("Delete check: offender ID {} still exists, so assuming an alias deletion", prisonerId)
-        prisonerIndexService.sync(offender)
+        prisonerIndexService.reindex(offender)
       }
     } else {
       customEventForMissingOffenderIdDisplay(message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/PrisonerSyncServiceTest.kt
@@ -32,7 +32,7 @@ class PrisonerSyncServiceTest {
         OffenderChangedMessage(eventType = "type", offenderId = 1, offenderIdDisplay = prisonerNumber)
       )
 
-      verify(prisonerIndexService).sync(offenderBooking)
+      verify(prisonerIndexService).reindex(offenderBooking)
     }
 
     @Test


### PR DESCRIPTION
Allows a partial update if Incentive  services fails this means main record is updated but the incentive element will remain as previous version - but will retried since message still goes on DLQ