### PR TITLE
SDI-641 Try using a startup probe

### DIFF
--- a/helm_deploy/prisoner-offender-search/Chart.yaml
+++ b/helm_deploy/prisoner-offender-search/Chart.yaml
@@ -5,7 +5,7 @@ name: prisoner-offender-search
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.4.0
+    version: 2.5.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.1.0

--- a/helm_deploy/prisoner-offender-search/values.yaml
+++ b/helm_deploy/prisoner-offender-search/values.yaml
@@ -44,11 +44,20 @@ generic-service:
     requests:
       memory: 856Mi
 
-  livenessProbe:
-    failureThreshold: 20
+  startupProbe:
+    httpGet:
+      path: /health/liveness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 30
 
-  readinessProbe:
-    failureThreshold: 20
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
 
   env:
     SERVER_PORT: "8080"


### PR DESCRIPTION
During deployment Spring Boot apps need a CPU burst and we've found that sometimes one of the pods isn't given enough CPU by Kubernetes to support this burst and so takes a long time to startup. By using a startup probe we can give the pods a longer window to start without affecting the liveness probe which desn't kick in until the startup probe is finished.