### PR TITLE
SDIT-650 Experiment with CPU request to fix slow startup

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,6 +22,12 @@ generic-service:
     prum-test-platform-2: "18.133.201.123/32"
     prum-test-platform-3: "52.56.76.34/32"
 
+  resources:
+    limits:
+      cpu: 2000m
+    requests:
+      cpu: 1000m
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 generic-prometheus-alerts:
   alertSeverity: syscon


### PR DESCRIPTION
We keep seeing the occasional pod that starts so slowly it breaks the liveness probe and gets restarted multiple times. This experiment is to see if a largee CPU request fixes this problem by forcing the scheduler to provision more CPU to the pod.