### PR TITLE
SDIT-771 Allow ability to manually publish prisoner-offender-search.prisoner.received

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/DomainEventsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/DomainEventsResource.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.prisonersearch.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.prisonersearch.services.HmppsDomainEventEmitter
+import java.time.LocalDateTime
+import java.time.ZoneId
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+
+@RestController
+@Validated
+class DomainEventsResource(private val domainEventEmitter: HmppsDomainEventEmitter) {
+  @PutMapping("/events/prisoner/received/{prisonerNumber}")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  @Operation(
+    summary = "Fires a domain event 'prisoner-offender-search.prisoner.received'. This is to be used in a catastrophic failure scenario when the original event was not raised",
+    description = "Requires EVENTS_ADMIN role",
+  )
+  @PreAuthorize("hasRole('ROLE_EVENTS_ADMIN')")
+  fun raisePrisonerReceivedEvent(
+    @Parameter(
+      required = true,
+      example = "A1234AA",
+    )
+    @NotNull
+    @Pattern(regexp = "[a-zA-Z][0-9]{4}[a-zA-Z]{2}")
+    @PathVariable("prisonerNumber")
+    prisonerNumber: String,
+
+    @RequestBody
+    @Valid
+    details: PrisonerReceivedEventDetails,
+
+  ) = domainEventEmitter.emitPrisonerReceiveEvent(
+    prisonerNumber,
+    details.reason,
+    details.prisonId,
+    occurredAt = details.occurredAt.atZone(ZoneId.of("Europe/London")).toInstant(),
+  )
+}
+
+data class PrisonerReceivedEventDetails(
+  @Schema(description = "reason for receive event", required = true, example = "TRANSFERRED")
+  val reason: HmppsDomainEventEmitter.PrisonerReceiveReason,
+  @Schema(description = "prison agency id of new prison", required = true, example = "WWI")
+  val prisonId: String,
+  @Schema(description = "local date time movement happened", required = true, example = "2023-02-28T12:34:56")
+  val occurredAt: LocalDateTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
@@ -32,7 +32,7 @@ class HmppsDomainEventEmitter(
   private val objectMapper: ObjectMapper,
   private val hmppsQueueService: HmppsQueueService,
   private val diffProperties: DiffProperties,
-  private val clock: Clock,
+  private val clock: Clock?,
   private val telemetryClient: TelemetryClient,
 ) {
 
@@ -92,11 +92,11 @@ class HmppsDomainEventEmitter(
     offenderNo: String,
     reason: PrisonerReceiveReason,
     prisonId: String,
-    occurredAt: Instant = Instant.now(clock),
+    occurredAt: Instant? = null,
   ) {
     PrisonerReceivedDomainEvent(
       PrisonerReceivedEvent(offenderNo, reason, prisonId),
-      occurredAt,
+      occurredAt ?: Instant.now(clock),
       diffProperties.host,
     ).publish()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/services/HmppsDomainEventEmitter.kt
@@ -92,10 +92,11 @@ class HmppsDomainEventEmitter(
     offenderNo: String,
     reason: PrisonerReceiveReason,
     prisonId: String,
+    occurredAt: Instant = Instant.now(clock),
   ) {
     PrisonerReceivedDomainEvent(
       PrisonerReceivedEvent(offenderNo, reason, prisonId),
-      Instant.now(clock),
+      occurredAt,
       diffProperties.host,
     ).publish()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/DomainEventsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/resource/DomainEventsResourceTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.prisonersearch.resource
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.prisonersearch.QueueIntegrationTest
+import uk.gov.justice.digital.hmpps.prisonersearch.services.MsgBody
+import uk.gov.justice.hmpps.sqs.PurgeQueueRequest
+
+class DomainEventsResourceTest : QueueIntegrationTest() {
+
+  @BeforeEach
+  fun purgeHmppsEventsQueue() {
+    with(hmppsEventsQueue) {
+      hmppsQueueService.purgeQueue(PurgeQueueRequest(queueName, sqsClient, queueUrl))
+    }
+  }
+
+  @Test
+  fun `access forbidden when no authority`() {
+    webTestClient
+      .put()
+      .uri("/events/prisoner/received/A2483AA")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+        {
+          "reason": "TRANSFERRED",
+          "prisonId": "WWI",
+          "occurredAt": "2020-07-19T12:30:12"
+        }
+      """,
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `access forbidden when no role`() {
+    webTestClient
+      .put()
+      .uri("/events/prisoner/received/A2483AA")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+        {
+          "reason": "TRANSFERRED",
+          "prisonId": "WWI",
+          "occurredAt": "2020-07-19T12:30:12"
+        }
+      """,
+        ),
+      )
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `sends prisoner receive event to the domain topic`() {
+    webTestClient
+      .put()
+      .uri("/events/prisoner/received/A2483AA")
+      .contentType(MediaType.APPLICATION_JSON)
+      .body(
+        BodyInserters.fromValue(
+          """
+        {
+          "reason": "TRANSFERRED",
+          "prisonId": "WWI",
+          "occurredAt": "2020-07-19T12:30:12"
+        }
+      """,
+        ),
+      )
+      .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
+      .exchange()
+      .expectStatus()
+      .isAccepted
+
+    await untilCallTo { getNumberOfMessagesCurrentlyOnDomainQueue() } matches { it == 1 }
+
+    val message = readNextDomainEventMessage()
+
+    assertThatJson(message).node("eventType").isEqualTo("prisoner-offender-search.prisoner.received")
+    assertThatJson(message).node("version").isEqualTo(1)
+    assertThatJson(message).node("occurredAt").isEqualTo("2020-07-19T12:30:12+01:00")
+    assertThatJson(message).node("additionalInformation.nomsNumber").isEqualTo("A2483AA")
+    assertThatJson(message).node("additionalInformation.reason").isEqualTo("TRANSFERRED")
+  }
+
+  fun readNextDomainEventMessage(): String {
+    val updateResult = hmppsEventsQueue.sqsClient.receiveMessage(hmppsEventsQueue.queueUrl).messages.first()
+    hmppsEventsQueue.sqsClient.deleteMessage(hmppsEventsQueue.queueUrl, updateResult.receiptHandle)
+    return objectMapper.readValue<MsgBody>(updateResult.body).Message
+  }
+}


### PR DESCRIPTION
This feature will be used to retrospectively fire domain events after a catastrophic failure.

It will be initially used to create 3 domain events from a failure back in February 